### PR TITLE
feat: adding field `Request` to record metric request statement

### DIFF
--- a/modules/elastic/common/domain.go
+++ b/modules/elastic/common/domain.go
@@ -103,6 +103,8 @@ type MetricItem struct {
 	Group string `json:"group"`
 	Order int `json:"order"`
 	OnlyPrimary bool `json:"only_primary"`
+	//current query statement that passed to search engine
+	Request string `json:"request"`
 }
 
 const TermsBucket string="terms"


### PR DESCRIPTION
adding field Request to record metric request statement, and then we can show the metric request statement in UI