### PR TITLE
feat: add util to validate request

### DIFF
--- a/lib/fasthttp/http.go
+++ b/lib/fasthttp/http.go
@@ -2166,6 +2166,14 @@ func (req *Request) String() string {
 	return getHTTPString(req)
 }
 
+func (req *Request) Validate() bool {
+	host:= req.Host()
+	if host==nil||len(host)==0{
+		return false
+	}
+	return true
+}
+
 // String returns response representation.
 //
 // Returns error message instead of response representation on error.


### PR DESCRIPTION
This pull request introduces a new method to the `Request` struct in the `lib/fasthttp/http.go` file to validate the request's host. The most important change is the addition of the `Validate` method, which checks if the host is non-nil and non-empty.

Validation addition:

* [`lib/fasthttp/http.go`](diffhunk://#diff-1c2282f696a8d7b10894fbfafaf37111fbb6987425398978674f801c57cd6021R2169-R2176): Added a `Validate` method to the `Request` struct to ensure the host is present and non-empty.