### PR TITLE
fix: avoid copy atomic value

### DIFF
--- a/core/task/task.go
+++ b/core/task/task.go
@@ -75,6 +75,11 @@ func registerTransientTask(group,tag string, f func(ctx context.Context) error, 
 	task.CreateTime = time.Now()
 	task.State = Pending
 	task.Ctx = ctxInput
+
+	if task.isTaskRunning==nil{
+		task.isTaskRunning=&atomic.Bool{}
+	}
+
 	Tasks.Store(task.ID, &task)
 
 	go func(func2 func(ctx context.Context) error) {
@@ -134,7 +139,7 @@ type ScheduleTask struct {
 	State    State           `config:"state" json:"state,omitempty"`
 	Ctx      context.Context `config:"-" json:"-"` //for transient task
 
-	isTaskRunning  atomic.Bool
+	isTaskRunning  *atomic.Bool
 }
 
 const Interval = "interval"
@@ -151,6 +156,10 @@ func RegisterScheduleTask(task ScheduleTask) (taskID string) {
 		task.Type = Interval
 	} else if task.Type == "" && task.Crontab != "" {
 		task.Type = Crontab
+	}
+
+	if task.isTaskRunning==nil{
+		task.isTaskRunning=&atomic.Bool{}
 	}
 
 	tempTask := task.Task


### PR DESCRIPTION
Fix warning: `
Call of 'task.RegisterScheduleTask' copies the lock value: type 'task.ScheduleTask' contains 'atomic.Bool' contains 'interface{}' which is 'sync.Locker' 
`

This warning is a result of Go’s strict handling of types containing atomic fields or synchronization primitives (e.g., sync.Locker). When such types are copied, it can cause subtle bugs because the copied value shares access to underlying synchronization mechanisms or memory.


This pull request includes changes to the `core/task/task.go` file to improve the handling of the `isTaskRunning` field in task structures. The changes ensure that `isTaskRunning` is properly initialized as a pointer to an `atomic.Bool`.

Initialization improvements:

* [`core/task/task.go`](diffhunk://#diff-2f9f5c5794e6f62c51694839d6a1f5731f6ea7825693e30efe643335b90a672fR78-R82): Added initialization of `isTaskRunning` as a pointer to an `atomic.Bool` in the `registerTransientTask` function.
* [`core/task/task.go`](diffhunk://#diff-2f9f5c5794e6f62c51694839d6a1f5731f6ea7825693e30efe643335b90a672fL137-R142): Changed the `isTaskRunning` field in the `ScheduleTask` struct to be a pointer to an `atomic.Bool` instead of a direct `atomic.Bool` instance.
* [`core/task/task.go`](diffhunk://#diff-2f9f5c5794e6f62c51694839d6a1f5731f6ea7825693e30efe643335b90a672fR161-R164): Added initialization of `isTaskRunning` as a pointer to an `atomic.Bool` in the `RegisterScheduleTask` function.