### PR TITLE
feat: recording cluster allocation explain to activity after cluster hea…

### DIFF
--- a/core/elastic/api.go
+++ b/core/elastic/api.go
@@ -137,6 +137,7 @@ type API interface {
 	DeleteILMPolicy(target string) error
 	GetRemoteInfo()([]byte, error)
 	Flush(indexName string) ([]byte, error)
+	ClusterAllocationExplain(ctx context.Context, body []byte, params url.Values)([]byte,error)
 }
 
 type TemplateAPI interface {

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,12 @@ Information about release notes of INFINI Framework is provided here.
 
 ### Improvements
 
+## v1.0.1
+### Bug fix
+### Features
+- Record cluster allocation explain to activity after cluster health status changed to `red`
+- Add elastic api method `ClusterAllocationExplain`
+
 ## v1.0.0
 
 ### 🚀 Features

--- a/modules/elastic/adapter/elasticsearch/v0.go
+++ b/modules/elastic/adapter/elasticsearch/v0.go
@@ -1907,3 +1907,22 @@ func (c *ESAPIV0) PutScript(scriptName string, script []byte)([]byte,error){
 func (c *ESAPIV0)SearchByTemplate(indexName,scriptName string,params map[string]interface{}) (*elastic.SearchResponse, error)  {
 	panic("not implemented")
 }
+
+func (c *ESAPIV0) ClusterAllocationExplain(ctx context.Context, body []byte, params url.Values)([]byte,error){
+	url := fmt.Sprintf("%s/_cluster/allocation/explain", c.GetEndpoint())
+	if len(params) > 0 {
+		url = fmt.Sprintf("%s?%s", url, params.Encode())
+	}
+	method := util.Verb_GET
+	if len(body) > 0 {
+		method = util.Verb_POST
+	}
+	resp, err := c.Request(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf(string(resp.Body))
+	}
+	return resp.Body, nil
+}


### PR DESCRIPTION
## What does this PR do
- recording cluster allocation explain to activity after cluster health status changed to `red`
- adding elastic api method `ClusterAllocationExplain`

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation