### PR TITLE
fix: remove shell usage to prevent missing file error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,14 +225,18 @@ init:
 	@# Extract the latest commit hash from the framework repository
 	@(cd $(FRAMEWORK_FOLDER) && git rev-parse HEAD > $(FRAMEWORK_FOLDER)/.latest_commit_hash.txt)
 	@(cd $(FRAMEWORK_VENDOR_FOLDER) && git rev-parse HEAD > $(FRAMEWORK_VENDOR_FOLDER)/.latest_commit_hash.txt)
-	@echo "Framework commit hash updated: $(shell cat $(FRAMEWORK_FOLDER)/.latest_commit_hash.txt)"
-	@echo "Framework vendor commit hash updated: $(shell cat $(FRAMEWORK_VENDOR_FOLDER)/.latest_commit_hash.txt)"
+	@echo "Framework commit hash updated: " && cat $(FRAMEWORK_FOLDER)/.latest_commit_hash.txt
+	@echo "Framework vendor commit hash updated: " && cat $(FRAMEWORK_VENDOR_FOLDER)/.latest_commit_hash.txt
 
 update-generated-framework-info:
 	@echo "update generated framework info"
-	@if [ ! -d $(FRAMEWORK_FOLDER) ]; then echo "framework does not exist";(make init) fi
-	@( cd $(FRAMEWORK_FOLDER) && echo -e "package config\n\nconst LastFrameworkCommitLog = \"$(shell cat $(FRAMEWORK_FOLDER)/.latest_commit_hash.txt)\"" > config/generated_framework-info.go)
-	@( cd $(FRAMEWORK_FOLDER) && echo -e "\nconst LastFrameworkVendorCommitLog = \"$(shell cat $(FRAMEWORK_VENDOR_FOLDER)/.latest_commit_hash.txt)\"" >> config/generated_framework-info.go)
+	@if [ ! -d $(FRAMEWORK_FOLDER) ]; then echo "framework does not exist"; (make init); fi
+	@echo "update info"
+	@# Generate the framework info file
+	@(cd $(FRAMEWORK_FOLDER) && \
+	 LATEST_COMMIT_LOG=$$(cat .latest_commit_hash.txt) && \
+	 VENDOR_COMMIT_LOG=$$(cat $(FRAMEWORK_VENDOR_FOLDER)/.latest_commit_hash.txt) && \
+	 echo -e "package config\n\nconst LastFrameworkCommitLog = \"$$LATEST_COMMIT_LOG\"\nconst LastFrameworkVendorCommitLog = \"$$VENDOR_COMMIT_LOG\"" > config/generated_framework-info.go)
 
 update-generated-file: update-generated-framework-info
 	@echo "update generated application info"

--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,8 @@ init:
 	@echo "Framework vendor commit hash updated: " && cat $(FRAMEWORK_VENDOR_FOLDER)/.latest_commit_hash.txt
 
 update-generated-framework-info:
-	@echo "update generated framework info"
+	@echo "generating framework info"
 	@if [ ! -d $(FRAMEWORK_FOLDER) ]; then echo "framework does not exist"; (make init); fi
-	@echo "update info"
 	@# Generate the framework info file
 	@(cd $(FRAMEWORK_FOLDER) && \
 	 LATEST_COMMIT_LOG=$$(cat .latest_commit_hash.txt) && \
@@ -239,7 +238,7 @@ update-generated-framework-info:
 	 echo -e "package config\n\nconst LastFrameworkCommitLog = \"$$LATEST_COMMIT_LOG\"\nconst LastFrameworkVendorCommitLog = \"$$VENDOR_COMMIT_LOG\"" > config/generated_framework-info.go)
 
 update-generated-file: update-generated-framework-info
-	@echo "update generated application info"
+	@echo "generating application info"
 	@if [ ! -d config ]; then echo "config does not exist";(mkdir config) fi
 	@echo -e "package config\n\nconst LastCommitLog = \"$(COMMIT_ID)\"\nconst BuildDate = \"$(NOW)\"" > config/generated.go
 	@echo -e "\nconst EOLDate  = \"$(APP_EOLDate)\"" >> config/generated.go
@@ -247,12 +246,12 @@ update-generated-file: update-generated-framework-info
 	@echo -e "\nconst BuildNumber  = \"$(BUILD_NUMBER)\"" >> config/generated.go
 
 restore-generated-framework-info:
-	@echo "restore generated framework info"
+	@echo "restore framework info"
 	@( cd $(FRAMEWORK_FOLDER) && echo -e "package config\n\nconst LastFrameworkCommitLog = \"N/A\"" > config/generated_framework-info.go)
 	@( cd $(FRAMEWORK_FOLDER) && echo -e "\nconst LastFrameworkVendorCommitLog = \"N/A\"" >> config/generated_framework-info.go )
 
 restore-generated-file: restore-generated-framework-info
-	@echo "restore generated application info"
+	@echo "restore application info"
 	@echo -e "package config\n\nconst LastCommitLog = \"N/A\"\nconst BuildDate = \"N/A\"" > config/generated.go
 	@echo -e "\nconst EOLDate = \"N/A\"" >> config/generated.go
 	@echo -e "\nconst Version = \"0.0.1-SNAPSHOT\"" >> config/generated.go


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

You will see some error like this:
```
➜  gateway git:(main) ✗ OFFLINE_BUILD=true make build               
cat: /Users/medcl/go/src/infini.sh/framework/.latest_commit_hash.txt: No such file or directory
```

Why This Happens?

Make evaluates $(shell ...) while parsing the Makefile to substitute the result into the command list. For example, in this line:

The $(shell cat ...) is evaluated as soon as Make parses the Makefile. If the file .latest_commit_hash.txt does not exist at this point, you’ll see the error.

The file .latest_commit_hash.txt does not yet exist when $(shell ...) is evaluated. This leads to the error.

In this PR,  we remove shell, and fixed the error.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation