### PR TITLE
fix: enable skipping to the next file with multiple gaps

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -19,10 +19,11 @@ Information about release notes of INFINI Framework is provided here.
 - Remove the collection of cluster stats metric in node stats collection task (#17)
 - Fix the main switch of the cluster metric is not work (#17)
 - Update elastic metadata safely (#20)
+- Enable skipping to the next file with multiple gaps #22
 
 ### Improvements
-- chore: add commit hashes for framework and managed vendor dependencies
-- chore: trim spaces from input variables during app initialization
+- Add commit hashes for framework and managed vendor dependencies
+- Trim spaces from input variables during app initialization
 
 
 ## v1.0.0

--- a/modules/queue/disk_queue/consumer.go
+++ b/modules/queue/disk_queue/consumer.go
@@ -479,10 +479,9 @@ func (d *Consumer) ResetOffset(segment, readPos int64) error {
 
 	//TODO, only if next file exists, and current file is not the last file, we should reload the file
 	//before move to next file, make sure, the current file is loaded completely, otherwise, we may lost some messages
-
 	if !exists {
 		//double check, but next file exists
-		if !util.FileExists(fileName) && next_file_exists {
+		if !util.FileExists(fileName) {
 			if d.mCfg.AutoSkipCorruptFile {
 				nextSegment := d.segment + 1
 				if nextSegment > d.diskQueue.writeSegmentNum {
@@ -512,7 +511,7 @@ func (d *Consumer) ResetOffset(segment, readPos int64) error {
 				return errors.New(fileName + " not found and auto_skip_corrupt_file not enabled.")
 			}
 		}
-		return errors.Errorf("current file: " + fileName + " not found, and next_file_exists not exists.")
+		return errors.Errorf("current file: %v not found, and next_file_exists: %v.",fileName,next_file_exists)
 	}
 
 FIND_NEXT_FILE:


### PR DESCRIPTION
## What does this PR do

Previously, the process would halt if more than one gap was encountered, requiring manual intervention. This fix allows seamless progression to the next file, even when multiple gaps are present, improving workflow efficiency.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation