### PR TITLE
fix: the issue that the cluster cannot recover from the unavailable s…

### DIFF
--- a/core/elastic/actions.go
+++ b/core/elastic/actions.go
@@ -411,7 +411,9 @@ func (meta *ElasticsearchMetadata) ReportSuccess() {
 	defer meta.configLock.Unlock()
 
 	if !meta.clusterAvailable {
-		if rate.GetRateLimiter("cluster_available", meta.Config.Name, 1, 1, time.Second*1).Allow() {
+		allowedUpdate := rate.GetRateLimiter("cluster_available", meta.Config.Name, 10, 1, time.Second*1).Allow()
+		log.Infof("update elasticsearch [%v] to available, allowedUpdate:[%v]", meta.Config.Name, allowedUpdate)
+		if allowedUpdate {
 			log.Tracef("vote success ticket++ for elasticsearch [%v]", meta.Config.Name)
 			meta.clusterAvailable = true
 			meta.clusterFailureTicket = 0

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -19,6 +19,7 @@ Information about release notes of INFINI Framework is provided here.
 - Remove the collection of cluster stats metric in node stats collection task (#17)
 - Fix the main switch of the cluster metric is not work (#17)
 - Update elastic metadata safely (#20)
+- Fixed the issue that the metadata does not take effect immediately after the cluster changes to available (#23)
 
 ### Improvements
 - chore: add commit hashes for framework and managed vendor dependencies


### PR DESCRIPTION
## What does this PR do
Fix the issue that the cluster cannot recover from the unavailable status
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation