### PR TITLE
feat: add `min_bucket_size` and `hits_total` to metric configurations

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of INFINI Framework is provided here.
 - Set the metric collection task to singleton mode (#17)
 - Record cluster allocation explain to activity after cluster health status changed to `red`
 - Add elastic api method `ClusterAllocationExplain`
+- Add `min_bucket_size` and `hits_total` to metric configurations (#29)
 
 ### Breaking changes
 

--- a/modules/elastic/common/domain.go
+++ b/modules/elastic/common/domain.go
@@ -105,6 +105,10 @@ type MetricItem struct {
 	OnlyPrimary bool `json:"only_primary"`
 	//current query statement that passed to search engine
 	Request string `json:"request"`
+	//minimum bucket size in seconds for querying the metric
+	MinBucketSize int64 `json:"min_bucket_size"`
+	//total hits of search response
+	HitsTotal int64 `json:"hits_total"`
 }
 
 const TermsBucket string="terms"


### PR DESCRIPTION
## What does this PR do
add `min_bucket_size` and `hits_total` to metric configurations
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation