### PR TITLE
feat: add proxy settings to  config section

### DIFF
--- a/core/api/client.go
+++ b/core/api/client.go
@@ -28,12 +28,23 @@
 package api
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
+	log "github.com/cihub/seelog"
+	"golang.org/x/net/proxy"
 	"infini.sh/framework/core/config"
+	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
+	"infini.sh/framework/lib/fasthttp"
+	"infini.sh/framework/lib/fasthttp/fasthttpproxy"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
+	"sync"
 	"time"
 )
 
@@ -93,14 +104,252 @@ func GetClientTLSConfig(tlsConfig *config.TLSConfig) (*tls.Config, error) {
 }
 
 func NewHTTPClient(clientCfg *config.HTTPClientConfig) (*http.Client, error) {
-	tr := &http.Transport{
+	if clientCfg == nil {
+		panic("client config is nil")
+	}
+
+	// Custom dialer with proxy logic
+	dialer := &net.Dialer{
+		Timeout:   util.GetDurationOrDefault(clientCfg.DialTimeout, 2*time.Second),
+		DualStack: true,
+	}
+
+	transport := &http.Transport{
 		MaxConnsPerHost: clientCfg.MaxConnectionPerHost,
+		TLSClientConfig: SimpleGetTLSConfig(&clientCfg.TLSConfig),
 		ReadBufferSize:  clientCfg.ReadBufferSize,
 		WriteBufferSize: clientCfg.WriteBufferSize,
-		TLSClientConfig: SimpleGetTLSConfig(&clientCfg.TLSConfig),
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// Determine whether to use a proxy for this address
+			if clientCfg.Proxy.Enabled {
+				if ok, cfg := clientCfg.ValidateProxy(addr); ok {
+					if cfg != nil {
+						log.Infof("using proxy: %v for addr: %v", util.MustToJSON(cfg), addr)
+						if cfg.HTTPProxy != "" {
+							// HTTP proxy
+							proxyURL, err := url.Parse(cfg.HTTPProxy)
+							if err != nil {
+								return nil, fmt.Errorf("invalid HTTP proxy URL: %w", err)
+							}
+							proxy := http.ProxyURL(proxyURL)
+							req := &http.Request{URL: &url.URL{Host: addr}}
+							proxyURL, err = proxy(req)
+							if err != nil {
+								return nil, err
+							}
+							if proxyURL != nil {
+								return dialer.DialContext(ctx, network, proxyURL.Host)
+							}
+						} else if cfg.Socket5Proxy != "" {
+							// SOCKS5 proxy
+							socksDialer, err := proxy.SOCKS5("tcp", cfg.Socket5Proxy, nil, dialer)
+							if err != nil {
+								return nil, fmt.Errorf("error creating SOCKS5 dialer: %w", err)
+							}
+							return socksDialer.Dial(network, addr)
+						} else if cfg.UsingEnvironmentProxySettings {
+							// Use environment proxy settings
+							envProxy := http.ProxyFromEnvironment
+							req := &http.Request{URL: &url.URL{Host: addr}}
+							proxyURL, err := envProxy(req)
+							if err != nil {
+								return nil, err
+							}
+							if proxyURL != nil {
+								return dialer.DialContext(ctx, network, proxyURL.Host)
+							}
+						}
+					}
+				}
+			}
+
+			// Connect directly
+			return dialer.DialContext(ctx, network, addr)
+		},
 	}
+
 	return &http.Client{
 		Timeout:   util.GetDurationOrDefault(clientCfg.Timeout, 60*time.Second),
-		Transport: tr,
+		Transport: transport,
 	}, nil
+}
+
+var (
+	defaultHttpClient     *http.Client
+	defaultFastHttpClient *fasthttp.Client
+	fastHTTPClients       = sync.Map{}
+	httpClients           = sync.Map{}
+	clientInitLocker      = sync.RWMutex{}
+)
+
+func GetHttpClient(name string) *http.Client {
+
+	if v, ok := httpClients.Load(name); ok {
+		x, ok := v.(*http.Client)
+		if ok && x != nil {
+			return x
+		}
+	}
+
+	if global.Env().IsDebug {
+		log.Debugf("http client setting [%v] not found, using default", name)
+	}
+
+	//init client and save to store
+	if cfg, ok := global.Env().SystemConfig.HTTPClientConfig[name]; ok {
+		clientInitLocker.Lock()
+		defer clientInitLocker.Unlock()
+		v, ok := httpClients.Load(name)
+		if !ok {
+			client, err := NewHTTPClient(&cfg)
+			if client != nil && err == nil {
+				httpClients.Store(name, client)
+				return client
+			}
+		}
+		x, ok := v.(*http.Client)
+		if ok {
+			return x
+		}
+	}
+
+	if defaultHttpClient == nil {
+		panic("default http client should not be nil")
+	}
+
+	return defaultHttpClient
+}
+
+func GetFastHttpClient(name string) *fasthttp.Client {
+
+	if v, ok := fastHTTPClients.Load(name); ok {
+		x, ok := v.(*fasthttp.Client)
+		if ok && x != nil {
+			return x
+		}
+	}
+
+	if global.Env().IsDebug {
+		log.Debugf("fasthttp client setting [%v] not found, using default", name)
+	}
+
+	//init client and save to store
+	if cfg, ok := global.Env().SystemConfig.HTTPClientConfig[name]; ok {
+		clientInitLocker.Lock()
+		defer clientInitLocker.Unlock()
+		v, ok := fastHTTPClients.Load(name)
+		if !ok {
+			client := getFastHTTPClient(&cfg)
+			if client != nil {
+				fastHTTPClients.Store(name, client)
+				return client
+			}
+		}
+		x, ok := v.(*fasthttp.Client)
+		if ok {
+			return x
+		}
+	}
+
+	if defaultFastHttpClient == nil {
+		panic("default http client should not be nil")
+	}
+
+	return defaultFastHttpClient
+}
+
+func getFastHTTPClient(clientCfg *config.HTTPClientConfig) *fasthttp.Client {
+
+	if clientCfg == nil {
+		panic("client config is nil")
+	}
+
+	return &fasthttp.Client{
+		MaxConnsPerHost: clientCfg.MaxConnectionPerHost,
+		TLSConfig:       SimpleGetTLSConfig(&clientCfg.TLSConfig),
+		ReadTimeout:     util.GetDurationOrDefault(clientCfg.ReadTimeout, 60*time.Second),
+		WriteTimeout:    util.GetDurationOrDefault(clientCfg.ReadTimeout, 60*time.Second),
+		DialDualStack:   true,
+		ReadBufferSize:  clientCfg.ReadBufferSize,
+		WriteBufferSize: clientCfg.WriteBufferSize,
+		Dial: func(addr string) (net.Conn, error) {
+
+			// Determine whether to use a proxy for this address
+			if clientCfg.Proxy.Enabled {
+				if ok, cfg := clientCfg.ValidateProxy(addr); ok {
+					if cfg != nil {
+
+						log.Infof("using proxy: %v for addr: %v", util.MustToJSON(cfg), addr)
+
+						if cfg.HTTPProxy != "" {
+							dialer := fasthttpproxy.FasthttpHTTPDialer(cfg.HTTPProxy)
+							return dialer(addr)
+						} else if cfg.Socket5Proxy != "" {
+							dialer := fasthttpproxy.FasthttpSocksDialer(cfg.Socket5Proxy)
+							return dialer(addr)
+						} else if cfg.UsingEnvironmentProxySettings {
+							proxyDialer := fasthttpproxy.FasthttpProxyHTTPDialerTimeout(util.GetDurationOrDefault(clientCfg.DialTimeout, 2*time.Second))
+							return proxyDialer(addr)
+						}
+					}
+				}
+			}
+
+			// Connect directly
+			return fasthttp.DialTimeout(addr, util.GetDurationOrDefault(clientCfg.DialTimeout, 2*time.Second))
+		},
+	}
+}
+
+// UpdateProxyEnvironment sets the system environment variables based on the ProxyConfig.
+// It will override any existing environment variables with the new values provided in the config.
+func UpdateProxyEnvironment(cfg *config.ProxyConfig) {
+
+	if cfg.HTTPProxy != "" {
+		_ = os.Setenv("HTTP_PROXY", cfg.HTTPProxy)
+		_ = os.Setenv("HTTPS_PROXY", cfg.HTTPProxy)
+	} else {
+		// Clear the proxy if not set in the config
+		_ = os.Unsetenv("HTTP_PROXY")
+		_ = os.Unsetenv("HTTPS_PROXY")
+	}
+
+	if cfg.Socket5Proxy != "" {
+		// Optionally handle SOCKS5 proxies as an environment variable if needed
+		_ = os.Setenv("SOCKS5_PROXY", cfg.Socket5Proxy)
+	} else {
+		_ = os.Unsetenv("SOCKS5_PROXY")
+	}
+
+	if cfg.UsingEnvironmentProxySettings {
+		// Ensure other env-based proxy settings are respected
+		if os.Getenv("HTTP_PROXY") == "" || os.Getenv("HTTPS_PROXY") == "" {
+			_ = os.Setenv("HTTP_PROXY", cfg.HTTPProxy)
+			_ = os.Setenv("HTTPS_PROXY", cfg.HTTPProxy)
+		}
+	} else {
+		// Clear NO_PROXY if using manual configuration
+		_ = os.Unsetenv("NO_PROXY")
+	}
+}
+
+func init() {
+	global.RegisterInitCallback(func() {
+
+		//init the default client
+		clientCfg := global.Env().GetHTTPClientConfig("default", "")
+		defaultFastHttpClient = getFastHTTPClient(clientCfg)
+
+		var err error
+		defaultHttpClient, err = NewHTTPClient(clientCfg)
+		if err != nil {
+			panic(err)
+		}
+
+		if clientCfg.Proxy.OverrideSystemProxy{
+			log.Debugf("override system proxy settings: %v %s",util.MustToJSON(clientCfg.Proxy.DefaultProxyConfig))
+			UpdateProxyEnvironment(&clientCfg.Proxy.DefaultProxyConfig)
+		}
+
+	})
 }

--- a/core/config/system.go
+++ b/core/config/system.go
@@ -172,7 +172,7 @@ type SystemConfig struct {
 
 	Plugins []*Config `config:"plugins"`
 
-	HTTPClientConfig HTTPClientConfig `config:"http_client"`
+	HTTPClientConfig map[string]HTTPClientConfig `config:"http_client"`
 }
 
 type CookieConfig struct {
@@ -180,23 +180,97 @@ type CookieConfig struct {
 	Domain string `config:"domain"`
 }
 
+type ProxyConfig struct {
+	HTTPProxy                     string `config:"http_proxy"` //export HTTP_PROXY=http://username:password@proxy-url:port
+	Socket5Proxy                  string `config:"socket5_proxy"`
+	UsingEnvironmentProxySettings bool   `config:"using_proxy_env"` //using the the env(HTTP_PROXY, HTTPS_PROXY and NO_PROXY) configured HTTP proxy
+}
+
+func (c *HTTPClientConfig) init() {
+	if !c.initTempMap {
+		tempMap := map[string]bool{}
+		for _, v := range c.Proxy.Denied {
+			c.checkDomainMap[v] = false
+		}
+
+		for _, v := range c.Proxy.Permitted {
+			c.checkDomainMap[v] = true
+		}
+
+		c.checkDomainMap = tempMap
+		c.initTempMap = true
+	}
+}
+
+func (c *HTTPClientConfig) ValidateProxy(addr string) (bool, *ProxyConfig) { //allow to visit the proxy, the proxy setting
+
+	//init configs
+	c.init()
+
+	//check proxy rule for specify domain
+	if len(c.Proxy.Domains) > 0 {
+		//port are part of the domain, need exact match{
+		if v, ok := c.Proxy.Domains[addr]; ok {
+			return true, &v
+		}
+	}
+
+	if len(c.checkDomainMap) > 0 {
+
+		//any hit will be return
+		if v, ok := c.checkDomainMap[addr]; ok {
+			if v == false {
+				return false, nil
+			} else {
+				return true, &c.Proxy.DefaultProxyConfig
+			}
+		}
+
+		//only defined denied, the rest should permitted
+		if len(c.Proxy.Denied) > 0 && len(c.Proxy.Permitted) == 0 {
+			if v, ok := c.checkDomainMap[addr]; ok && v == false {
+				return false, nil
+			} else {
+				return true, &c.Proxy.DefaultProxyConfig
+			}
+		}
+
+		//only defined permitted, the rest should be consider denied
+		if len(c.Proxy.Permitted) > 0 && len(c.Proxy.Denied) == 0 {
+			if v, ok := c.checkDomainMap[addr]; ok && v == true {
+				return true, &c.Proxy.DefaultProxyConfig
+			} else {
+				return false, nil
+			}
+		}
+	}
+
+	return true, &c.Proxy.DefaultProxyConfig
+}
+
 type HTTPClientConfig struct {
-	Name       string `config:"name"`
-	HTTPProxy  string `config:"http_proxy"`
-	HTTPSProxy string `config:"https_proxy"`
+	Proxy struct {
+		Enabled             bool                   `config:"enabled"`
+		DefaultProxyConfig  ProxyConfig            `config:"config"`
+		Permitted           []string               `config:"permitted"`
+		Denied              []string               `config:"denied"`
+		Domains             map[string]ProxyConfig `config:"domains"` //proxy settings per domain
+		OverrideSystemProxy bool                   `config:"override_system_proxy_env"`
+	} `config:"proxy"`
 
 	Timeout              string    `config:"timeout"`
+	DialTimeout          string    `config:"dial_timeout"`
 	ReadTimeout          string    `config:"read_timeout"`
 	WriteTimeout         string    `config:"write_timeout"`
 	ReadBufferSize       int       `config:"read_buffer_size"`
 	WriteBufferSize      int       `config:"write_buffer_size"`
 	TLSConfig            TLSConfig `config:"tls"` //server or client's certs
 	MaxConnectionPerHost int       `config:"max_connection_per_host"`
-}
 
-//type HTTPClientConfigs struct {
-//	Default HTTPClientConfig `config:"default"`
-//}
+	//temp data structure
+	initTempMap    bool
+	checkDomainMap map[string]bool
+}
 
 type ConfigsConfig struct {
 	AutoReload                 bool      `config:"auto_reload"`                    //auto reload local files
@@ -249,13 +323,13 @@ type WebAppConfig struct {
 	WebsocketConfig WebsocketConfig `config:"websocket"`
 	//same with API Config
 
-	AuthConfig    AuthConfig     `config:"auth"` //enable access control for UI or not
-	UI            UIConfig       `config:"ui"`
-	BasePath      string         `config:"base_path"`
-	Domain        string         `config:"domain"`
-	EmbeddingAPI  bool           `config:"embedding_api"`
-	Gzip          GzipConfig     `config:"gzip"`
-	S3Config      S3BucketConfig `config:"s3"`
+	AuthConfig   AuthConfig     `config:"auth"` //enable access control for UI or not
+	UI           UIConfig       `config:"ui"`
+	BasePath     string         `config:"base_path"`
+	Domain       string         `config:"domain"`
+	EmbeddingAPI bool           `config:"embedding_api"`
+	Gzip         GzipConfig     `config:"gzip"`
+	S3Config     S3BucketConfig `config:"s3"`
 }
 
 type S3Config struct {

--- a/core/config/system.go
+++ b/core/config/system.go
@@ -251,7 +251,7 @@ func (c *HTTPClientConfig) ValidateProxy(addr string) (bool, *ProxyConfig) { //a
 type HTTPClientConfig struct {
 	Proxy struct {
 		Enabled             bool                   `config:"enabled"`
-		DefaultProxyConfig  ProxyConfig            `config:"config"`
+		DefaultProxyConfig  ProxyConfig            `config:"default_config"`
 		Permitted           []string               `config:"permitted"`
 		Denied              []string               `config:"denied"`
 		Domains             map[string]ProxyConfig `config:"domains"` //proxy settings per domain

--- a/core/env/env.go
+++ b/core/env/env.go
@@ -338,14 +338,6 @@ func GetDefaultSystemConfig() config.SystemConfig {
 			MaxBackupFiles:             10,
 			ValidConfigsExtensions:     []string{".tpl", ".json", ".yml", ".yaml"},
 		},
-		HTTPClientConfig: config.HTTPClientConfig{
-			ReadBufferSize:       100 * 1024,
-			WriteBufferSize:      100 * 1024,
-			ReadTimeout:          "60s",
-			WriteTimeout:         "60s",
-			MaxConnectionPerHost: 1000,
-			TLSConfig:            config.TLSConfig{SkipDomainVerify: true, TLSInsecureSkipVerify: true},
-		},
 	}
 }
 

--- a/core/env/http_client.go
+++ b/core/env/http_client.go
@@ -29,7 +29,19 @@ package env
 
 import "infini.sh/framework/core/config"
 
-func  (env *Env)  GetClientConfigByEndpoint(tag,endpoint string) *config.HTTPClientConfig  {
+func  (env *Env) GetHTTPClientConfig(name, endpoint string) *config.HTTPClientConfig  {
+	clientCfg,ok := env.SystemConfig.HTTPClientConfig[name]
+	if !ok{
+		clientCfg=config.HTTPClientConfig{
+			ReadBufferSize:       100 * 1024,
+			WriteBufferSize:      100 * 1024,
+			ReadTimeout:          "60s",
+			WriteTimeout:         "60s",
+			MaxConnectionPerHost: 1000,
+			TLSConfig:            config.TLSConfig{SkipDomainVerify: true, TLSInsecureSkipVerify: true},
+		}
+	}
 	//TODO support client config per endpoint
-	return &env.SystemConfig.HTTPClientConfig
+	return &clientCfg
 }
+

--- a/docs/content.en/docs/references/http_client.md
+++ b/docs/content.en/docs/references/http_client.md
@@ -14,7 +14,7 @@ http_client:
   default:
     proxy:
       enabled: true
-      config:
+      default_config:
         http_proxy: http://127.0.0.1:7890
         socket5_proxy: socks5://127.0.0.1:7890
       override_system_proxy_env: true # Override system proxy environment settings
@@ -24,6 +24,10 @@ http_client:
         - "localhost"
         - "infinilabs.com"
         - "api.coco.rs"
+      domains:
+        "github.com":
+          http_proxy: http://127.0.0.1:7890
+          socket5_proxy: socks5://127.0.0.1:7890
   custom_profile:
     proxy:
       enabled: false
@@ -58,11 +62,11 @@ http_client:
 | Name                        | Type    | Description                                                                 |
 |-----------------------------|---------|-----------------------------------------------------------------------------|
 | `enabled`                   | boolean | Enables or disables the use of a proxy.                                    |
-| `config`                    | ProxyDetails | Default proxy settings, including HTTP and SOCKS5 proxies.                 |
+| `default_config`                    | ProxyDetails | Default proxy settings, including HTTP and SOCKS5 proxies.                 |
 | `override_system_proxy_env` | boolean | Whether to override system-wide proxy environment variables.                |
 | `permitted`                 | list    | List of domains allowed to use the proxy.                                  |
 | `denied`                    | list    | List of domains denied from using the proxy.                               |
-| `domains`                    | list    | Proxy settings per domain.                               |
+| `domains`                    | map    | Proxy settings per domain.                               |
 
 ---
 

--- a/docs/content.en/docs/references/http_client.md
+++ b/docs/content.en/docs/references/http_client.md
@@ -1,0 +1,74 @@
+---
+title: "Http Client"
+weight: 50
+---
+
+# HTTP Client Configuration
+
+The `http_client` section defines configurations for HTTP clients, where each key represents a unique client profile. The `default` key is a special profile that serves as the fallback configuration when no specific profile is specified. Additional profiles can be added and accessed dynamically.
+
+## Sample Configuration
+
+```yaml
+http_client:
+  default:
+    proxy:
+      enabled: true
+      config:
+        http_proxy: http://127.0.0.1:7890
+        socket5_proxy: socks5://127.0.0.1:7890
+      override_system_proxy_env: true # Override system proxy environment settings
+      permitted:
+        - "google.com"
+      denied:
+        - "localhost"
+        - "infinilabs.com"
+        - "api.coco.rs"
+  custom_profile:
+    proxy:
+      enabled: false
+```
+
+# Parameters
+
+## HTTP Client Configuration: `http_client`
+| Name   | Type                       | Description                                                                 |
+|--------|----------------------------|-----------------------------------------------------------------------------|
+| `key`  | map[string]HTTPClientConfig | Each key represents a named HTTP client configuration. For example, `default` or `custom`. |
+| `default` | HTTPClientConfig         | The default configuration used as a fallback when no specific configuration is specified. |
+
+---
+
+## HTTP Client Config: `HTTPClientConfig`
+| Name                        | Type      | Description                                                                 |
+|-----------------------------|-----------|-----------------------------------------------------------------------------|
+| `proxy`                     | ProxyConfig | Configuration for proxy usage, including domain rules and proxy settings.   |
+| `timeout`                   | string    | The overall timeout for HTTP requests.                                      |
+| `dial_timeout`              | string    | The timeout for establishing connections.                                   |
+| `read_timeout`              | string    | The timeout for reading data from the connection.                          |
+| `write_timeout`             | string    | The timeout for writing data to the connection.                            |
+| `read_buffer_size`          | int       | The size of the read buffer.                                               |
+| `write_buffer_size`         | int       | The size of the write buffer.                                              |
+| `tls_config`                | TLSConfig | Configuration for TLS settings.                                            |
+| `max_connection_per_host`   | int       | The maximum number of connections per host.                                |
+
+---
+
+## Proxy Configuration: `ProxyConfig`
+| Name                        | Type    | Description                                                                 |
+|-----------------------------|---------|-----------------------------------------------------------------------------|
+| `enabled`                   | boolean | Enables or disables the use of a proxy.                                    |
+| `config`                    | ProxyDetails | Default proxy settings, including HTTP and SOCKS5 proxies.                 |
+| `override_system_proxy_env` | boolean | Whether to override system-wide proxy environment variables.                |
+| `permitted`                 | list    | List of domains allowed to use the proxy.                                  |
+| `denied`                    | list    | List of domains denied from using the proxy.                               |
+| `domains`                    | list    | Proxy settings per domain.                               |
+
+---
+
+## Proxy Details: `ProxyDetails`
+| Name                        | Type    | Description                                                                 |
+|-----------------------------|---------|-----------------------------------------------------------------------------|
+| `http_proxy`                | string  | URL of the HTTP proxy.                                                     |
+| `socket5_proxy`             | string  | URL of the SOCKS5 proxy.                                                   |
+| `using_proxy_env`           | boolean | Whether to use system environment proxy settings (e.g., `HTTP_PROXY`).      |

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -13,6 +13,7 @@ Information about release notes of INFINI Framework is provided here.
 - Record cluster allocation explain to activity after cluster health status changed to `red`
 - Add elastic api method `ClusterAllocationExplain`
 - Add `min_bucket_size` and `hits_total` to metric configurations (#29)
+- Add proxy settings to `http_client` config section
 
 ### Breaking changes
 

--- a/modules/configs/client/client.go
+++ b/modules/configs/client/client.go
@@ -123,7 +123,7 @@ func ListenConfigChanges() error {
 	clientInitLock.Do(func() {
 
 		if global.Env().SystemConfig.Configs.Managed {
-			cfg := global.Env().GetClientConfigByEndpoint("configs", "")
+			cfg := global.Env().GetHTTPClientConfig("configs", "")
 			if cfg != nil {
 				hClient, err := api.NewHTTPClient(cfg)
 				if err != nil {


### PR DESCRIPTION
## What does this PR do

Closes https://github.com/infinilabs/framework/issues/32

This PR introduces the ability to configure proxy settings for the HTTP client, enabling seamless operation in environments with network access restrictions. If your App or HTTP requests requires a proxy for network access, you can leverage this feature to configure proxy settings as follows:

```
http_client:
  default:
    proxy:
      enabled: true
      default_config:
        http_proxy: http://127.0.0.1:7890
        socket5_proxy: socks5://127.0.0.1:7890
      override_system_proxy_env: true # Override system proxy environment settings
      permitted:
        - "google.com"
      denied:
        - "localhost"
        - "infinilabs.com"
        - "api.coco.rs"
      domains:
        "github.com":
          http_proxy: http://127.0.0.1:7890
          socket5_proxy: socks5://127.0.0.1:7890
  custom_profile:
    proxy:
      enabled: false

```


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [x] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation