### PR TITLE
fix: metrics collection after cluster recovery from unavailability

### DIFF
--- a/modules/elastic/metadata.go
+++ b/modules/elastic/metadata.go
@@ -85,7 +85,6 @@ func (module *ElasticModule) clusterHealthCheck(clusterID string, force bool) {
 				}
 				log.Tracef("cluster [%v] health [%v] updated", clusterID, metadata.Health)
 			}
-			metadata.ReportSuccess()
 			changes, err := util.DiffTwoObject(metadata.Health, health)
 			if err != nil {
 				log.Errorf("diff cluster health error: %v", err)
@@ -93,8 +92,11 @@ func (module *ElasticModule) clusterHealthCheck(clusterID string, force bool) {
 			if len(changes) > 0 {
 				//copy metadata and update metadata safely
 				newMeta := *metadata
+				newMeta.ReportSuccess()
 				newMeta.Health = health
 				elastic.SetMetadata(metadata.Config.ID, &newMeta)
+			}else{
+				metadata.ReportSuccess()
 			}
 		}
 	}

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -107,8 +107,17 @@ func (module *MetricsModule) Setup() {
 	elastic2.RegisterMetadataChangeEvent(func(meta, oldMeta *elastic2.ElasticsearchMetadata, action elastic2.EventAction) {
 		if action == elastic2.EventActionUpdate && oldMeta != nil {
 			//skip if no monitor config changed
+			hasChanged := false
 			changelog, _ := util.DiffTwoObject(oldMeta.Config.MonitorConfigs, meta.Config.MonitorConfigs)
-			if len(changelog) == 0 {
+			if len(changelog) > 0 {
+				hasChanged = true
+			}else if meta != nil {
+				// check other conditions
+				hasChanged = meta.IsAvailable() != oldMeta.IsAvailable() ||
+					meta.Config.Enabled != oldMeta.Config.Enabled ||
+					meta.Config.Monitored != oldMeta.Config.Monitored
+			}
+			if !hasChanged {
 				return
 			}
 		}


### PR DESCRIPTION
## What does this PR do
fix metrics collection after cluster recovery from unavailability
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation