### PR TITLE
perform system cluster health check only when it is set up

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -21,7 +21,6 @@ Information about release notes of INFINI Framework is provided here.
 ### Bug fix
 - Remove the collection of cluster stats metric in node stats collection task (#17)
 - Fix the main switch of the cluster metric is not work (#17)
-- Update elastic metadata safely (#20)
 - Fixed the issue that the metadata does not take effect immediately after the cluster changes to available (#23)
 - Enable skipping to the next file with multiple gaps (#22)
 - Removing the logic of collecting metric per each node (#26)

--- a/modules/api/api.go
+++ b/modules/api/api.go
@@ -84,23 +84,24 @@ func healthAPIHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Pa
 	}
 
 	services := global.Env().GetServicesHealth()
-	globalID := global.MustLookupString(elastic.GlobalSystemElasticsearchID)
-	meta := elastic.GetMetadata(globalID)
-	if meta != nil {
-		services["system_cluster"] = meta.Health.Status
-		healthType := env.GetHealthType(meta.Health.Status)
-		if healthType > overallHealthType {
-			overallHealthType = healthType
-			obj["status"] = overallHealthType.ToString()
-		}
-	}
-
-	if len(services) > 0 {
-		obj["services"] = services
-	}
 
 	if global.Env().SetupRequired() {
 		obj["setup_required"] = global.Env().SetupRequired()
+	}else{
+		//perform system cluster health check only when it is set up
+		globalID := global.MustLookupString(elastic.GlobalSystemElasticsearchID)
+		meta := elastic.GetMetadata(globalID)
+		if meta != nil {
+			services["system_cluster"] = meta.Health.Status
+			healthType := env.GetHealthType(meta.Health.Status)
+			if healthType > overallHealthType {
+				overallHealthType = healthType
+				obj["status"] = overallHealthType.ToString()
+			}
+		}
+	}
+	if len(services) > 0 {
+		obj["services"] = services
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/modules/elastic/metadata.go
+++ b/modules/elastic/metadata.go
@@ -87,14 +87,9 @@ func (module *ElasticModule) clusterHealthCheck(clusterID string, force bool) {
 			if err != nil {
 				log.Errorf("diff cluster health error: %v", err)
 			}
+			metadata.ReportSuccess()
 			if len(changes) > 0 {
-				//copy metadata and update metadata safely
-				newMeta := *metadata
-				newMeta.ReportSuccess()
-				newMeta.Health = health
-				elastic.SetMetadata(metadata.Config.ID, &newMeta)
-			}else{
-				metadata.ReportSuccess()
+				metadata.Health = health
 			}
 		}
 	}
@@ -241,10 +236,7 @@ func (module *ElasticModule) updateClusterState(clusterId string,force bool) {
 			if meta.Config.Source == elastic.ElasticsearchConfigSourceElasticsearch {
 				module.saveRoutingTable(state, clusterId)
 			}
-			//copy metadata and update metadata safely
-			newMeta := *meta
-			newMeta.ClusterState = state
-			elastic.SetMetadata(meta.Config.ID, &newMeta)
+			meta.ClusterState = state
 		}
 	}
 }
@@ -784,11 +776,8 @@ func (module *ElasticModule) updateNodeInfo(meta *elastic.ElasticsearchMetadata,
 		}
 
 		if discovery || force {
-			//copy metadata and update metadata safely
-			newMeta := *meta
-			newMeta.Nodes = nodes
-			newMeta.NodesTopologyVersion++
-			elastic.SetMetadata(meta.Config.ID, &newMeta)
+			meta.Nodes = nodes
+			meta.NodesTopologyVersion++
 
 			log.Tracef("cluster nodes [%v] updated", meta.Config.Name)
 
@@ -1183,9 +1172,7 @@ func updateAliases(meta *elastic.ElasticsearchMetadata, force bool) {
 	}
 
 	if aliasesChanged {
-		newMeta := *meta
-		newMeta.Aliases = aliases
-		elastic.SetMetadata(meta.Config.ID, &newMeta)
+		meta.Aliases = aliases
 		log.Tracef("cluster aliases [%v] updated", meta.Config.Name)
 	}
 }


### PR DESCRIPTION
## What does this PR do
perform system cluster health check only when it is set up, fix #39
## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation