### PR TITLE
fix: perform system cluster health check only when it is set up

### DIFF
--- a/modules/api/api.go
+++ b/modules/api/api.go
@@ -84,23 +84,24 @@ func healthAPIHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Pa
 	}
 
 	services := global.Env().GetServicesHealth()
-	globalID := global.MustLookupString(elastic.GlobalSystemElasticsearchID)
-	meta := elastic.GetMetadata(globalID)
-	if meta != nil {
-		services["system_cluster"] = meta.Health.Status
-		healthType := env.GetHealthType(meta.Health.Status)
-		if healthType > overallHealthType {
-			overallHealthType = healthType
-			obj["status"] = overallHealthType.ToString()
-		}
-	}
-
-	if len(services) > 0 {
-		obj["services"] = services
-	}
 
 	if global.Env().SetupRequired() {
 		obj["setup_required"] = global.Env().SetupRequired()
+	}else{
+		//perform system cluster health check only when it is set up
+		globalID := global.MustLookupString(elastic.GlobalSystemElasticsearchID)
+		meta := elastic.GetMetadata(globalID)
+		if meta != nil {
+			services["system_cluster"] = meta.Health.Status
+			healthType := env.GetHealthType(meta.Health.Status)
+			if healthType > overallHealthType {
+				overallHealthType = healthType
+				obj["status"] = overallHealthType.ToString()
+			}
+		}
+	}
+	if len(services) > 0 {
+		obj["services"] = services
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## What does this PR do
perform system cluster health check only when it is set up, fix #39 
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation