### PR TITLE
chore: fix invalid data folder, remove cluster_config and use appname directly for configuration

### DIFF
--- a/core/env/env.go
+++ b/core/env/env.go
@@ -94,9 +94,9 @@ type Env struct {
 	state int32 //0 means running, 1 means stopping, 2 means stopped
 }
 
-func (env *Env) CheckSetup() error {
+func (env *Env) CheckSetup() {
 	if !env.allowSetup {
-		return nil
+		return
 	}
 
 	env.setupRequired = false
@@ -105,7 +105,7 @@ func (env *Env) CheckSetup() error {
 	if !util.FileExists(setupLock) {
 		env.setupRequired = true
 	}
-	return nil
+	return
 }
 
 func (env *Env) EnableSetup(b bool) {
@@ -244,7 +244,6 @@ func (env *Env) InitPaths(cfgPath string) error {
 	defaultConfig := GetDefaultSystemConfig()
 	_, defaultConfig.NodeConfig.IP, _, _ = util.GetPublishNetworkDeviceInfo("")
 	env.SystemConfig = &defaultConfig
-	env.SystemConfig.ClusterConfig.Name = env.GetAppLowercaseName()
 	env.SystemConfig.Configs.PanicOnConfigError = !env.IgnoreOnConfigMissing //if ignore on config missing, then no panic on config error
 
 	var (
@@ -412,6 +411,7 @@ func (env *Env) loadEnvFromConfigFile(filename string) error {
 		panic(err)
 		return err
 	}
+
 	env.SystemConfig = &tempCfg
 	//initialize node config
 	env.findWorkingDir()
@@ -595,7 +595,6 @@ func NewEnv(name, desc, ver, buildNumber, commit, buildDate, eolDate, terminalHe
 
 func EmptyEnv() *Env {
 	system := GetDefaultSystemConfig()
-	system.ClusterConfig.Name = "app"
 	system.PathConfig.Data = os.TempDir()
 	system.PathConfig.Log = os.TempDir()
 	system.LoggingConfig.DisableFileOutput = true
@@ -644,7 +643,7 @@ func (env *Env) findWorkingDir() (string, string) {
 	//no folder exists, generate new id and name
 	//persist metadata to folder
 
-	baseDir := path.Join(env.SystemConfig.PathConfig.Data, env.SystemConfig.ClusterConfig.Name, "nodes")
+	baseDir := path.Join(env.SystemConfig.PathConfig.Data, env.GetAppLowercaseName(), "nodes")
 
 	if !util.FileExists(baseDir) {
 		if env.SystemConfig.NodeConfig.ID == "" {
@@ -784,8 +783,8 @@ func GetConfigAsJSON() string {
 func (env *Env) getNodeWorkingDir(nodeID string) (string, string) {
 	env.SystemConfig.NodeConfig.ID = nodeID
 
-	dataDir := path.Join(env.SystemConfig.PathConfig.Data, env.SystemConfig.ClusterConfig.Name, "nodes", nodeID)
-	logDir := path.Join(env.SystemConfig.PathConfig.Log, env.SystemConfig.ClusterConfig.Name, "nodes", nodeID)
+	dataDir := path.Join(env.SystemConfig.PathConfig.Data, env.GetAppLowercaseName(), "nodes", nodeID)
+	logDir := path.Join(env.SystemConfig.PathConfig.Log, env.GetAppLowercaseName(), "nodes", nodeID)
 
 	//try get node name from meta file
 	metaFile := path.Join(dataDir, ".meta")

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -27,6 +27,7 @@ Information about release notes of INFINI Framework is provided here.
 - Removing the logic of collecting metric per each node (#26)
 - Fixed to parse password from basic auth (#31)
 - Fixed issue with metric collection task interval not working (#30)
+- Fix invalid data folder, remove cluster_config and use appname directly for configuration (#46)
 
 
 ### Improvements


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation