### PR TITLE
test: for ci test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,6 @@ package-windows-platform:
 	cd $(OUTPUT_DIR) && zip -r $(OUTPUT_DIR)/windows-386.zip   $(APP_NAME)-windows-386.exe $(APP_CONFIG)
 
 test: config
-	$(GOTEST) -v $(GOFLAGS) -timeout 60s ./...
+	$(GOTEST) -v $(GOFLAGS) -timeout 600s ./...
 	@$(MAKE) restore-generated-file
 

--- a/Makefile
+++ b/Makefile
@@ -324,5 +324,7 @@ package-windows-platform:
 	cd $(OUTPUT_DIR) && zip -r $(OUTPUT_DIR)/windows-amd64.zip   $(APP_NAME)-windows-amd64.exe $(APP_CONFIG)
 	cd $(OUTPUT_DIR) && zip -r $(OUTPUT_DIR)/windows-386.zip   $(APP_NAME)-windows-386.exe $(APP_CONFIG)
 
-test:
-	$(GOTEST) -timeout 60s ./...
+test: config
+	$(GOTEST) -v $(GOFLAGS) -timeout 60s ./...
+	@$(MAKE) restore-generated-file
+


### PR DESCRIPTION
## What does this PR do
This pull request includes changes to the `Makefile` in the `package-windows-platform` to improve the testing process. The most important change is the addition of a configuration step before running tests and the restoration of a generated file after tests are run.

Changes to the testing process:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L327-R330): Modified the `test` target to include a `config` step before running tests, added verbose flag `-v` to `$(GOTEST)`, and included a step to restore a generated file after tests are run.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation