### PR TITLE
ci: for code lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ endif
 GO        := GO15VENDOREXPERIMENT="1" GO111MODULE=off go
 GOBUILD  := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) GRPC_GO_REQUIRE_HANDSHAKE=off  $(GO) build -a $(FRAMEWORK_DEVEL_BUILD) -gcflags=all="-l -B"  -ldflags '-static' -ldflags='-s -w' -gcflags "-m"  --work $(GOBUILD_FLAGS)
 GOBUILDNCGO  := GOPATH=$(NEWGOPATH) CGO_ENABLED=1  $(GO) build -ldflags -s $(GOBUILD_FLAGS)
-GOTEST   := GOPATH=$(NEWGOPATH) CGO_ENABLED=1  $(GO) test -ldflags -s
+GOTEST   := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) $(GO) test -ldflags -s
+GOLINT   := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) $(GO) vet -ldflags -s
 
 ARCH      := "`uname -s`"
 LINUX     := "Linux"
@@ -328,3 +329,6 @@ test: config
 	$(GOTEST) -v $(GOFLAGS) -timeout 600s ./...
 	@$(MAKE) restore-generated-file
 
+lint: config
+	$(GOLINT) -v $(GOFLAGS) ./...
+	@$(MAKE) restore-generated-file

--- a/Makefile
+++ b/Makefile
@@ -330,5 +330,5 @@ test: config
 	@$(MAKE) restore-generated-file
 
 lint: config
-	$(GOLINT) -v $(GOFLAGS) ./...
+	$(GOLINT) -c=2 -v $(GOFLAGS) ./...
 	@$(MAKE) restore-generated-file


### PR DESCRIPTION
## What does this PR do
 ci code lint for pr
## Rationale for this change
This pull request includes changes to the `Makefile` to enhance the build and testing processes by introducing a linting step and improving the configuration of the `GOTEST` command.

Improvements to build and testing processes:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L77-R78): Modified the `GOTEST` command to use the `APP_NEED_CGO` variable for the `CGO_ENABLED` setting, ensuring consistent behavior based on the application's CGO requirements.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R332-R334): Added a new `GOLINT` command to enable linting with `go vet`, and introduced a `lint` target to the makefile to run this command.
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation