### PR TITLE
feat: add util to http handler, support write bytes with status code 

### DIFF
--- a/core/api/handler.go
+++ b/core/api/handler.go
@@ -160,17 +160,22 @@ func (handler Handler) WriteError(w http.ResponseWriter, errMessage string, stat
 }
 
 func (handler Handler) WriteJSON(w http.ResponseWriter, v interface{}, statusCode int) error {
-	if !handler.wroteHeader {
-		handler.WriteJSONHeader(w)
-		w.WriteHeader(statusCode)
-	}
-
 	b, err := handler.EncodeJSON(v)
 	if err != nil {
 		w.Write([]byte(err.Error()))
 		return err
 	}
-	_, err = w.Write(b)
+
+	return handler.WriteBytes(w,b,statusCode)
+}
+
+func (handler Handler) WriteBytes(w http.ResponseWriter, b []byte, statusCode int) error {
+	if !handler.wroteHeader {
+		handler.WriteJSONHeader(w)
+		w.WriteHeader(statusCode)
+	}
+
+	_, err := w.Write(b)
 	if err != nil {
 		w.Write([]byte(err.Error()))
 		return err

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,8 @@ Information about release notes of INFINI Framework is provided here.
 - Add `min_bucket_size` and `hits_total` to metric configurations (#29)
 - Add proxy settings to `http_client` config section (#33)
 - Add new condition to check item length (eg: array,string) (#38)
+- Add util to http handler, support write bytes with status code (#55)
+
 
 ### Breaking changes
 - Update WebSocket greeting message header to use `websocket-session-id`


### PR DESCRIPTION
## What does this PR do
add util to http handler, support write bytes with status code
## Rationale for this change
This pull request includes changes to improve the handling of HTTP responses and updates to the release notes documentation. The most important changes include refactoring the `WriteJSON` method to use a new `WriteBytes` method, and updating the release notes to reflect the new utility added to the HTTP handler.

Improvements to HTTP response handling:

* [`core/api/handler.go`](diffhunk://#diff-d7ecb439c9f4ce5dc7fc00d000ce3579ac2666a18054b58cb27ff126d745f30eL163-R178): Refactored the `WriteJSON` method to use a new `WriteBytes` method for writing byte arrays with a status code. This change ensures that the header is written only once.

Documentation updates:

* [`docs/content.en/docs/release-notes/_index.md`](diffhunk://#diff-6a5ab1b382c7b8d732e1667c4b8b236b020871d8f02badb577c84a938e5826f5R18-R19): Updated the release notes to include information about the new utility added to the HTTP handler for writing bytes with a status code.
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation