### PR TITLE
chore: update release notes for v1.1.0

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -8,6 +8,17 @@ title: "Release Notes"
 Information about release notes of INFINI Framework is provided here.
 
 ## Latest (In development)
+
+### Breaking changes
+### Features
+### Bug fix
+### Improvements
+
+## v1.1.0 (2025-01-11) 
+
+### Breaking changes
+- Update WebSocket greeting message header to use `websocket-session-id`
+
 ### Features
 - Set the metric collection task to singleton mode (#17)
 - Record cluster allocation explain to activity after cluster health status changed to `red`
@@ -16,10 +27,6 @@ Information about release notes of INFINI Framework is provided here.
 - Add proxy settings to `http_client` config section (#33)
 - Add new condition to check item length (eg: array,string) (#38)
 - Add util to http handler, support write bytes with status code (#55)
-
-
-### Breaking changes
-- Update WebSocket greeting message header to use `websocket-session-id`
 
 ### Bug fix
 - Remove the collection of cluster stats metric in node stats collection task (#17)
@@ -39,7 +46,7 @@ Information about release notes of INFINI Framework is provided here.
 - Add search response to logging message (#28)
 
 
-## v1.0.0
+## v1.0.0 (2024-12-13) 
 
 ### 🚀 Features
 


### PR DESCRIPTION
## What does this PR do
 release notes
## Rationale for this change
This pull request updates the release notes for the INFINI Framework in the `docs/content.en/docs/release-notes/_index.md` file. The changes include adding new sections for breaking changes, features, bug fixes, and improvements, as well as updating the release notes for version 1.1.0 and version 1.0.0 with specific dates.

Release notes updates:

* Added new sections for breaking changes, features, bug fixes, and improvements under the "Latest (In development)" section.
* Updated the release notes for version 1.1.0 with the release date "2025-01-11" and included a breaking change regarding the WebSocket greeting message header.
* Removed duplicate breaking changes entry for version 1.1.0.
* Updated the release notes for version 1.0.0 with the release date "2024-12-13".
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation