### PR TITLE
chore: enable metadata_refresh by default

### DIFF
--- a/modules/elastic/module.go
+++ b/modules/elastic/module.go
@@ -67,8 +67,8 @@ var (
 			Interval: "10s",
 		},
 		MetadataRefresh: common.CheckConfig{
-			Enabled:  false,
-			Interval: "10s",
+			Enabled:  true,
+			Interval: "30s",
 		},
 		ORMConfig: common.ORMConfig{
 			Enabled:                 false,
@@ -685,6 +685,9 @@ func (module *ElasticModule) refreshAllClusterMetadata() {
 		}
 
 		v, ok := value.(*elastic.ElasticsearchMetadata)
+
+		log.Trace("update elasticsearch's metadata:", v, ok)
+
 		if ok {
 			module.updateNodeInfo(v, false, v.Config.Discovery.Enabled)
 		}


### PR DESCRIPTION
## What does this PR do
Enable metadata_refresh by default 
## Rationale for this change
This pull request to `modules/elastic/module.go` includes changes to enable metadata refresh and add logging for Elasticsearch metadata updates. The most important changes are:

Metadata refresh configuration:

* [`modules/elastic/module.go`](diffhunk://#diff-fa0cefecf570cf5b4cfbc279b6c12092a20e53726d4a79bcb9aa285f1c52d575L70-R71): Enabled metadata refresh by setting `Enabled` to `true` and changed the `Interval` from "10s" to "30s" in the `MetadataRefresh` configuration.

Logging improvements:

* [`modules/elastic/module.go`](diffhunk://#diff-fa0cefecf570cf5b4cfbc279b6c12092a20e53726d4a79bcb9aa285f1c52d575R688-R690): Added a trace log statement to log Elasticsearch metadata updates in the `refreshAllClusterMetadata` function.
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation