### PR TITLE
feat: add new search function to orm module, support result item mapper

### DIFF
--- a/core/orm/mapper.go
+++ b/core/orm/mapper.go
@@ -1,0 +1,26 @@
+/* Copyright © INFINI LTD. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package orm
+
+import (
+	"errors"
+	"infini.sh/framework/core/util"
+	"reflect"
+)
+
+func MapToStructWithJSONUnmarshal(source []byte, targetRef interface{}) error {
+
+	// Ensure target is a pointer
+	if reflect.ValueOf(targetRef).Kind() != reflect.Ptr {
+		return errors.New("target must be a pointer")
+	}
+
+	// Unmarshal the JSON into the target struct
+	if err := util.FromJSONBytes(source, targetRef); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/core/orm/mapper.go
+++ b/core/orm/mapper.go
@@ -1,6 +1,25 @@
-/* Copyright © INFINI LTD. All rights reserved.
- * Web: https://infinilabs.com
- * Email: hello#infini.ltd */
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 package orm
 

--- a/core/orm/mapper_test.go
+++ b/core/orm/mapper_test.go
@@ -1,6 +1,25 @@
-/* Copyright © INFINI LTD. All rights reserved.
- * Web: https://infinilabs.com
- * Email: hello#infini.ltd */
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 package orm
 

--- a/core/orm/mapper_test.go
+++ b/core/orm/mapper_test.go
@@ -1,0 +1,65 @@
+/* Copyright © INFINI LTD. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package orm
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMapToStructWithJSONUnmarshal(t *testing.T) {
+	type SampleStruct struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}
+
+	tests := []struct {
+		name        string
+		source      []byte
+		target      interface{}
+		expected    SampleStruct
+		expectError bool
+	}{
+		{
+			name:   "Valid JSON",
+			source: []byte(`{"id":1,"name":"John","email":"john@example.com"}`),
+			target: &SampleStruct{},
+			expected: SampleStruct{
+				ID:    1,
+				Name:  "John",
+				Email: "john@example.com",
+			},
+			expectError: false,
+		},
+		{
+			name:        "Invalid JSON",
+			source:      []byte(`{"id":1,"name":"John","email":"john@example.com"`), // Missing closing brace
+			target:      &SampleStruct{},
+			expected:    SampleStruct{},
+			expectError: true,
+		},
+		{
+			name:        "Target is not a pointer",
+			source:      []byte(`{"id":1,"name":"John","email":"john@example.com"}`),
+			target:      SampleStruct{},
+			expected:    SampleStruct{},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := MapToStructWithJSONUnmarshal(tt.source, tt.target)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, *(tt.target.(*SampleStruct)))
+			}
+		})
+	}
+}

--- a/core/orm/orm.go
+++ b/core/orm/orm.go
@@ -70,6 +70,8 @@ type ORM interface {
 
 	Search(o interface{}, q *Query) (error, Result)
 
+	SearchWithResultItemMapper(resultArrayRef interface{}, itemMapFunc func(source []byte, targetRef interface{}) error, q *Query) (error, SimpleResult) //	var results []ObjectItem; orm.SearchWithResultItemMapper(&results, mapperFunc, &query)
+
 	Get(o interface{}) (bool, error)
 
 	GetBy(field string, value interface{}, o interface{}) (error, Result)
@@ -292,6 +294,11 @@ type Result struct {
 	Result []interface{}
 }
 
+type SimpleResult struct {
+	Total int64
+	Raw   []byte
+}
+
 func Get(o interface{}) (bool, error) {
 	rValue := reflect.ValueOf(o)
 
@@ -460,6 +467,14 @@ func Count(o interface{}, query interface{}) (int64, error) {
 
 func Search(o interface{}, q *Query) (error, Result) {
 	return getHandler().Search(o, q)
+}
+
+func SearchWithResultItemMapper(o interface{}, itemMapFunc func(source []byte, targetRef interface{}) error, q *Query) (error, SimpleResult) {
+	return getHandler().SearchWithResultItemMapper(o, itemMapFunc, q)
+}
+
+func SearchWithJSONMapper(o interface{}, q *Query) (error, SimpleResult) {
+	return getHandler().SearchWithResultItemMapper(o, MapToStructWithJSONUnmarshal, q)
 }
 
 func GroupBy(o interface{}, selectField, groupField, haveQuery string, haveValue interface{}) (error, map[string]interface{}) {

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,6 +11,8 @@ Information about release notes of INFINI Framework is provided here.
 
 ### Breaking changes
 ### Features
+- Add new search function to orm module, support result item mapper (#65)
+
 ### Bug fix
 ### Improvements
 - Add util to http handler, support to parse bool parameter


### PR DESCRIPTION
## What does this PR do

This PR introduces improvements to the search functionality, addressing its current simplicity and lack of optimization for performance.

Key Changes:
- Custom Mapper Functionality: Search results can now be parsed using a user-defined mapper function, enabling more flexible and tailored result handling.
- Future Performance Enhancements: This sets the groundwork for low-level search operations to return raw bytes directly to the mapper, reducing processing overhead and improving performance.

By implementing these changes, we aim to provide better extensibility and prepare for advanced optimizations in upcoming iterations.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation