### PR TITLE
feat:  add new stats api to quickly find the top N keys from a Badger DB

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of INFINI Framework is provided here.
 ### Breaking changes
 ### Features
 - Add new search function to orm module, support result item mapper (#65)
+- Add new stats api to quickly find the top N keys from a Badger DB (#67)
 
 ### Bug fix
 ### Improvements

--- a/plugins/badger/api.go
+++ b/plugins/badger/api.go
@@ -1,0 +1,184 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+/* Copyright © INFINI LTD. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package badger
+
+import (
+	log "github.com/cihub/seelog"
+	"github.com/dgraph-io/badger/v4"
+	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/util"
+	"net/http"
+	"sort"
+	"strconv"
+)
+
+const (
+	SortBySize  = "size"  // Constant to specify sorting by size
+	SortByCount = "count" // Constant to specify sorting by count
+)
+
+// dumpKeyStats handles the HTTP request for dumping key statistics from the Badger DB
+func (m *Module) dumpKeyStats(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	var stats []*KeyStats
+	strSize := req.URL.Query().Get("size")
+	sortKey := req.URL.Query().Get("sort")
+
+	// Set default sort method to "size" if not specified
+	if sortKey != SortByCount {
+		sortKey = SortBySize
+	}
+
+	size, err := strconv.Atoi(strSize)
+	if err != nil {
+		// If conversion fails, default size to 10
+		size = 10
+	}
+
+	// Initialize totalKeyCount to count the total number of keys across all buckets
+	var totalKeyCount int
+
+	// Iterate through all the buckets in the Range
+	buckets.Range(func(key, value any) bool {
+		// Extract the Badger DB instance from the bucket's value
+		db, ok := value.(*badger.DB)
+		if !ok {
+			log.Errorf("failed to get badger db for bucket %s", key)
+			return true
+		} else {
+			if db == nil {
+				log.Debugf("got empty badger db for bucket %s", key)
+				return true
+			}
+		}
+
+		// Get statistics for the current bucket, with key count and sorting option
+		partStats, keyCount, err := getBadgerStats(db, size, sortKey)
+		if err != nil {
+			log.Errorf("failed to get badger stats: %v", err)
+			return true
+		}
+		totalKeyCount += keyCount
+		if len(partStats) > 0 {
+			stats = append(stats, partStats...)
+		}
+		return true
+	})
+
+	// Sort the gathered statistics based on the specified "sort" parameter
+	if sortKey == SortBySize {
+		sort.Sort(BySize(stats)) // Sort by value size
+	} else {
+		sort.Sort(ByCount(stats)) // Sort by count
+	}
+
+	// Ensure we do not slice beyond the length of stats
+	if len(stats) < size {
+		size = len(stats) // If requested size is greater than the available stats, adjust size
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	w.Write(util.MustToJSONBytes(util.MapStr{
+		"total": totalKeyCount,       // Total number of keys across all buckets
+		"top_hits":           stats[:size], // The top N key statistics based on size or count
+	}))
+	w.WriteHeader(200)
+}
+
+
+// KeyStats represents the statistics for each key, including its occurrence count and value size.
+type KeyStats struct {
+	Key   string // The key itself
+	Count int    // The number of times the key appears in the database
+	Size  int64    // The size of the key's associated value
+}
+
+func getBadgerStats(db *badger.DB, size int, sortBy string) ([]*KeyStats, int, error) {
+
+	keyStats := make(map[string]*KeyStats)
+
+	// Perform a read-only transaction
+	err := db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close() // Make sure the iterator is closed when done
+
+		// Iterate through all the items in the database
+		for it.Rewind(); it.Valid(); it.Next() {
+			item := it.Item()
+			key := string(item.Key())
+			// Count the occurrence of the current key
+			if _, ok := keyStats[key]; !ok {
+				keyStats[key] = &KeyStats{
+					Key:   key,
+					Count: 1,
+					Size:  item.ValueSize(),
+				}
+			}else{
+				keyStats[key].Count++
+				keyStats[key].Size += item.ValueSize()
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Create a slice to store the statistics of each key
+	var stats = make([]*KeyStats, 0, len(keyStats))
+	for _, v := range keyStats {
+		stats = append(stats, v)
+	}
+	keyCount := len(stats)
+	// Sort the keys based on their occurrence count or value size
+	if sortBy == SortBySize {
+		sort.Sort(BySize(stats))
+	}else {
+		sort.Sort(ByCount(stats))
+	}
+	// Ensure we do not slice beyond the length of stats
+	if len(stats) < size {
+		size = len(stats)
+	}
+	return stats[0: size], keyCount, nil
+}
+
+// ByCount implements sort.Interface to sort KeyStats by the occurrence count of each key.
+type ByCount []*KeyStats
+
+func (a ByCount) Len() int           { return len(a) }
+func (a ByCount) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByCount) Less(i, j int) bool { return a[i].Count > a[j].Count } // Sort in descending order of count
+
+// BySize implements sort.Interface to sort KeyStats by the size of the value for each key.
+type BySize []*KeyStats
+
+func (a BySize) Len() int           { return len(a) }
+func (a BySize) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a BySize) Less(i, j int) bool { return a[i].Size > a[j].Size } // Sort in descending order of value size

--- a/plugins/badger/api.go
+++ b/plugins/badger/api.go
@@ -34,7 +34,6 @@ import (
 	"infini.sh/framework/core/util"
 	"net/http"
 	"sort"
-	"strconv"
 )
 
 const (
@@ -45,19 +44,8 @@ const (
 // dumpKeyStats handles the HTTP request for dumping key statistics from the Badger DB
 func (m *Module) dumpKeyStats(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	var stats []*KeyStats
-	strSize := req.URL.Query().Get("size")
-	sortKey := req.URL.Query().Get("sort")
-
-	// Set default sort method to "size" if not specified
-	if sortKey != SortByCount {
-		sortKey = SortBySize
-	}
-
-	size, err := strconv.Atoi(strSize)
-	if err != nil {
-		// If conversion fails, default size to 10
-		size = 10
-	}
+	size := m.GetIntOrDefault(req, "size", 10)
+	sortKey := m.GetParameterOrDefault(req, "sort", SortBySize)
 
 	// Initialize totalKeyCount to count the total number of keys across all buckets
 	var totalKeyCount int

--- a/plugins/badger/module.go
+++ b/plugins/badger/module.go
@@ -29,6 +29,7 @@ package badger
 
 import (
 	"github.com/dgraph-io/badger/v4"
+	"infini.sh/framework/core/api"
 	"infini.sh/framework/core/env"
 	"infini.sh/framework/core/filter"
 	"infini.sh/framework/core/global"
@@ -95,6 +96,7 @@ func (module *Module) Setup() {
 	if module.cfg.Enabled {
 		filter.Register("badger", module)
 		kv.Register("badger", module)
+		api.HandleAPIMethod(api.GET, "/kv/badger/keys/_stats", module.dumpKeyStats)
 	}
 
 }

--- a/plugins/badger/module.go
+++ b/plugins/badger/module.go
@@ -63,6 +63,7 @@ type Module struct {
 	cfg    *Config
 	bucket *badger.DB
 	closed bool
+	api.Handler
 }
 
 func (module *Module) Name() string {

--- a/plugins/badger/module.go
+++ b/plugins/badger/module.go
@@ -97,7 +97,7 @@ func (module *Module) Setup() {
 	if module.cfg.Enabled {
 		filter.Register("badger", module)
 		kv.Register("badger", module)
-		api.HandleAPIMethod(api.GET, "/kv/badger/keys/_stats", module.dumpKeyStats)
+		api.HandleAPIMethod(api.GET, "/badger/stats", module.dumpKeyStats)
 	}
 
 }


### PR DESCRIPTION
## What does this PR do
This PR introduces a new API to retrieve the top N keys from a Badger DB, with sorting options based on either the key size or count. The API enhances the ability to quickly analyze key statistics and prioritize the most significant keys based on custom criteria.

### Key Changes:
- New API Endpoint:
  - A new API endpoint is added: `GET /badger/stats`, which returns the top N keys from the Badger DB.
  - This endpoint accepts the following query parameters:
    - `size`: The number of top keys to retrieve (default is 10).
    - `sort`: The sorting criteria, which can be size (sort by value size) or count (sort by key count).
- Efficient Key Retrieval:
  - The API uses a read-only transaction to iterate over all keys in the Badger DB.
  - For each key, the size and count are tracked and stored.
  - The top N keys are sorted based on the specified criteria and returned in the response.
- Sorting Options:
  - Users can choose to sort the keys by size (value size) or count (how many times the key appears).
  - The default sorting is by size if the sort query parameter is not provided.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation