### PR TITLE
fix: create file before put content to it

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,8 @@ Information about release notes of INFINI Framework is provided here.
 - Add new stats api to quickly find the top N keys from a Badger DB (#67)
 
 ### Bug fix
+- Fix client sync config panic when config folder not exits (#71)
+
 ### Improvements
 - Add util to http handler, support to parse bool parameter
 - Handle simplified bulk metdata, parse index from url path (#59)

--- a/modules/configs/config/config.go
+++ b/modules/configs/config/config.go
@@ -119,7 +119,6 @@ func SaveConfigStr(name, content string) error {
 	if err != nil {
 		return err
 	}
-
 	fileToSave := path.Join(cfgDir, name)
 
 	log.Info("write config file: ", fileToSave)
@@ -136,6 +135,11 @@ func SaveConfigStr(name, content string) error {
 				return err
 			}
 		}
+	}
+
+	_, err = util.CreateFile(cfgDir, "")
+	if err != nil {
+		return err
 	}
 
 	_, err = util.FilePutContent(fileToSave, content)

--- a/modules/configs/config/config.go
+++ b/modules/configs/config/config.go
@@ -137,7 +137,7 @@ func SaveConfigStr(name, content string) error {
 		}
 	}
 
-	_, err = util.CreateFile(cfgDir, "")
+	err = os.MkdirAll(cfgDir, 0755)
 	if err != nil {
 		return err
 	}

--- a/modules/configs/config/config_test.go
+++ b/modules/configs/config/config_test.go
@@ -7,6 +7,10 @@ package config
 import (
 	"fmt"
 	"github.com/magiconair/properties/assert"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/util"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -39,4 +43,37 @@ func TestVersion(t *testing.T) {
 
 	ver = parseConfigVersion("what's the version, i think is 1234")
 	assert.Equal(t, ver, int64(-1))
+}
+
+func TestSaveConfigStr(t *testing.T) {
+	cfgDir, err := filepath.Abs(global.Env().GetConfigDir())
+	if err != nil {
+		t.Fatalf("Failed to get config directory: %v", err)
+	}
+
+	testFileName := "test_config.yaml"
+	testContent := "test content"
+
+	err = SaveConfigStr(testFileName, testContent)
+	if err != nil {
+		t.Fatalf("SaveConfigStr failed: %v", err)
+	}
+
+	savedFilePath := filepath.Join(cfgDir, testFileName)
+	if !util.FileExists(savedFilePath) {
+		t.Fatalf("Expected file %s to exist", savedFilePath)
+	}
+
+	savedContent, err := util.FileGetContent(savedFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read saved file content: %v", err)
+	}
+
+	assert.Equal(t, string(savedContent), testContent)
+
+	// Clean up
+	err = os.Remove(savedFilePath)
+	if err != nil {
+		t.Fatalf("Failed to remove test file: %v", err)
+	}
 }


### PR DESCRIPTION
## What does this PR do
This pull request includes changes to the `SaveConfigStr` function in the `modules/configs/config/config.go` file to improve error handling and ensure the configuration directory exists before saving the configuration file.

Improvements to error handling and directory creation:

* Added a check to create the configuration directory if it does not exist before attempting to save the configuration file. (`modules/configs/config/config.go`, [modules/configs/config/config.goR140-R144](diffhunk://#diff-fdd202f68b86524d47407f638491e1572f1bd25aff830b81da035279798d0c64R140-R144))
* Removed unnecessary blank line for cleaner code. (`modules/configs/config/config.go`, [modules/configs/config/config.goL122](diffhunk://#diff-fdd202f68b86524d47407f638491e1572f1bd25aff830b81da035279798d0c64L122))
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation