### PR TITLE
refactor: const for ip zero or loopback address

### DIFF
--- a/core/api/api.go
+++ b/core/api/api.go
@@ -208,7 +208,7 @@ func StartAPI() {
 		listenAddress = apiConfig.NetworkConfig.GetBindingAddr()
 	}
 
-	if util.ContainStr(listenAddress, util.ReservedAddress) {
+	if util.ContainStr(listenAddress, util.AnyAddress) {
 		ips := util.GetLocalIPs()
 		if len(ips) > 0 {
 			log.Infof("local ips: %v", util.JoinArray(ips, ", "))

--- a/core/api/api.go
+++ b/core/api/api.go
@@ -208,7 +208,7 @@ func StartAPI() {
 		listenAddress = apiConfig.NetworkConfig.GetBindingAddr()
 	}
 
-	if util.ContainStr(listenAddress, "0.0.0.0") {
+	if util.ContainStr(listenAddress, util.ReservedAddress) {
 		ips := util.GetLocalIPs()
 		if len(ips) > 0 {
 			log.Infof("local ips: %v", util.JoinArray(ips, ", "))

--- a/core/host/process_info.go
+++ b/core/host/process_info.go
@@ -27,6 +27,7 @@ import (
 	"bufio"
 	"bytes"
 	log "github.com/cihub/seelog"
+	"infini.sh/framework/core/util"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -113,7 +114,7 @@ func getPortByPid(pid string) []int {
 
 func getPortByPidWindows(pid string) []int {
 	//netstat -ano|findStr /V "127.0.0.1" | findStr "780"
-	cmd := []string{"netstat", "-ano", "findStr", "/V", "127.0.0.1", "findStr", pid}
+	cmd := []string{"netstat", "-ano", "findStr", "/V", util.LocalAddress, "findStr", pid}
 	var stdout bytes.Buffer
 	c1 := exec.Command(cmd[0], cmd[1])
 	c2 := exec.Command(cmd[2], cmd[3], cmd[4])

--- a/core/util/netutils.go
+++ b/core/util/netutils.go
@@ -35,6 +35,15 @@ import (
 	"time"
 )
 
+// ReservedAddress is the reserved address
+const ReservedAddress = "0.0.0.0"
+
+// LocalIpv6Address is the local ipv6 address
+const LocalIpv6Address = "0.0.0.1"
+
+// LocalAddress is the local ipv4 address
+const LocalAddress = "127.0.0.1"
+
 //Class        Starting IPAddress    Ending IP Address    # of Hosts
 //A            10.0.0.0              10.255.255.255       16,777,216
 //B            172.16.0.0            172.31.255.255       1,048,576
@@ -173,7 +182,7 @@ func GetSafetyInternalAddress(addr string) string {
 
 	if strings.Contains(addr, ":") {
 		array := strings.Split(addr, ":")
-		if array[0] == "0.0.0.0" {
+		if array[0] == ReservedAddress {
 			array[0], _ = GetIntranetIP()
 		}
 		return strings.Join(array, ":")
@@ -192,7 +201,7 @@ func GetValidAddress(addr string) string {
 	if strings.Index(addr, ":") >= 0 {
 		array := strings.Split(addr, ":")
 		if len(array[0]) == 0 {
-			array[0] = "127.0.0.1"
+			array[0] = LocalAddress
 			addr = strings.Join(array, ":")
 		}
 	}
@@ -266,11 +275,11 @@ func GetLocalIPs() []string {
 // IsLocalAddress check if the address is local address
 func IsLocalAddress(address []string, localIPs []string) bool {
 	for _, add := range address {
-		if UnifyLocalAddress(add) == LOCAL_ADDRESS {
+		if UnifyLocalAddress(add) == LocalAddress {
 			continue
 		}
 
-		if add == "0.0.0.0" {
+		if add == ReservedAddress {
 			continue
 		}
 
@@ -360,7 +369,7 @@ func ClientIP(r *http.Request) string {
 
 	if ip, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr)); err == nil {
 		if ip == "::1" {
-			ip = "127.0.0.1"
+			ip = LocalAddress
 		}
 		return ip
 	}
@@ -368,16 +377,14 @@ func ClientIP(r *http.Request) string {
 	return ""
 }
 
-const LOCAL_ADDRESS = "127.0.0.1"
-
 func UnifyLocalAddress(host string) string {
 	//unify host
 	if ContainStr(host, "localhost") {
-		host = strings.Replace(host, "localhost", LOCAL_ADDRESS, -1)
+		host = strings.Replace(host, "localhost", LocalAddress, -1)
 	} else if ContainStr(host, "[::1]") {
-		host = strings.Replace(host, "[::1]", LOCAL_ADDRESS, -1)
+		host = strings.Replace(host, "[::1]", LocalAddress, -1)
 	} else if ContainStr(host, "::1") {
-		host = strings.Replace(host, "::1", LOCAL_ADDRESS, -1)
+		host = strings.Replace(host, "::1", LocalAddress, -1)
 	}
 	return host
 }

--- a/core/util/netutils.go
+++ b/core/util/netutils.go
@@ -35,8 +35,8 @@ import (
 	"time"
 )
 
-// ReservedAddress is the reserved address
-const ReservedAddress = "0.0.0.0"
+// AnyAddress is the reserved address
+const AnyAddress = "0.0.0.0"
 
 // LocalIpv6Address is the local ipv6 address
 const LocalIpv6Address = "0.0.0.1"
@@ -182,7 +182,7 @@ func GetSafetyInternalAddress(addr string) string {
 
 	if strings.Contains(addr, ":") {
 		array := strings.Split(addr, ":")
-		if array[0] == ReservedAddress {
+		if array[0] == AnyAddress {
 			array[0], _ = GetIntranetIP()
 		}
 		return strings.Join(array, ":")
@@ -279,7 +279,7 @@ func IsLocalAddress(address []string, localIPs []string) bool {
 			continue
 		}
 
-		if add == ReservedAddress {
+		if add == AnyAddress {
 			continue
 		}
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -19,7 +19,7 @@ Information about release notes of INFINI Framework is provided here.
 - Add util to http handler, support to parse bool parameter
 - Handle simplified bulk metdata, parse index from url path (#59)
 - Improve handling of message read for partially loaded files (#63)
-
+- Refactor loopback address to use const (#73)
 
 ## v1.1.0 (2025-01-11) 
 


### PR DESCRIPTION
## What does this PR do
This pull request includes changes to centralize and standardize the use of network address constants across the codebase. The most important changes include the introduction of new constants for reserved and local addresses, and the replacement of hardcoded address strings with these constants.

Centralization and standardization of network address constants:

* [`core/util/netutils.go`](diffhunk://#diff-3fa3772b0e7ad87ab2978e874a2324cafde5cedf6d5f4e6b810520f1b44a4320R38-R46): Introduced new constants `ReservedAddress`, `LocalIpv6Address`, and `LocalAddress` to represent common network addresses.
* [`core/util/netutils.go`](diffhunk://#diff-3fa3772b0e7ad87ab2978e874a2324cafde5cedf6d5f4e6b810520f1b44a4320L176-R185): Replaced hardcoded address strings with the newly defined constants in various functions, such as `GetSafetyInternalAddress`, `GetValidAddress`, `GetLocalIPs`, and `ClientIP`. [[1]](diffhunk://#diff-3fa3772b0e7ad87ab2978e874a2324cafde5cedf6d5f4e6b810520f1b44a4320L176-R185) [[2]](diffhunk://#diff-3fa3772b0e7ad87ab2978e874a2324cafde5cedf6d5f4e6b810520f1b44a4320L195-R204) [[3]](diffhunk://#diff-3fa3772b0e7ad87ab2978e874a2324cafde5cedf6d5f4e6b810520f1b44a4320L269-R282) [[4]](diffhunk://#diff-3fa3772b0e7ad87ab2978e874a2324cafde5cedf6d5f4e6b810520f1b44a4320L363-R387)

Refactoring to use new address constants:

* [`core/api/api.go`](diffhunk://#diff-5faa80368fcb83f22034d90a836248ce73eb18a7c87d51c9725f887578428e9aL211-R211): Updated the `StartAPI` function to use the `ReservedAddress` constant instead of the hardcoded "0.0.0.0" string.
* [`core/host/process_info.go`](diffhunk://#diff-b58c31419c114333af8b5f3154d2ae5885d7c470ddb40b0b3d71e6adc12813c4R30): Imported the `util` package and replaced hardcoded address strings with the new constants in the `getPortByPidWindows` function. [[1]](diffhunk://#diff-b58c31419c114333af8b5f3154d2ae5885d7c470ddb40b0b3d71e6adc12813c4R30) [[2]](diffhunk://#diff-b58c31419c114333af8b5f3154d2ae5885d7c470ddb40b0b3d71e6adc12813c4L116-R117)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation