### PR TITLE
fix: actions permissions and upgrade osv to 1.9.1

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -16,14 +16,16 @@ on:
     branches: [ "main" ]
 
 permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
-  # Read commit contents
+  # Only need to read contents
   contents: read
 
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.9.1"
     with:
       # Example of specifying custom arguments
       scan-args: |-

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -31,4 +31,4 @@ jobs:
       scan-args: |-
         -r
         --skip-git
-        ./
+        /github/workspace


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the `.github/workflows/osv-scanner.yml` file to improve the configuration and permissions for the OSV scanner workflow.

Changes to workflow configuration and permissions:

* Added permissions for `actions: read` to upload SARIF files to CodeQL.
* Updated the `scan-pr` job to use the latest reusable workflow version `v1.9.1` from `google/osv-scanner-action`.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation