### PR TITLE
fix: unsafe method panic, reduce log, slice work with id

### DIFF
--- a/core/util/bytes.go
+++ b/core/util/bytes.go
@@ -241,6 +241,9 @@ func UnsafeBytesToString(bs []byte) string {
 }
 
 func UnsafeStringToBytes(s string) []byte {
+	if len(s) == 0 {
+		return []byte{}
+	}
 	return *(*[]byte)(unsafe.Pointer(&s))
 }
 

--- a/core/util/bytes.go
+++ b/core/util/bytes.go
@@ -244,6 +244,13 @@ func UnsafeStringToBytes(s string) []byte {
 	return *(*[]byte)(unsafe.Pointer(&s))
 }
 
+func UnsafeGetStringToBytes(s string) []byte {
+	if len(s) == 0 {
+		return []byte{} // Handle empty string case to avoid nil slice
+	}
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}
+
 // ToLowercase convert string bytes to lowercase
 func ToLowercase(str []byte) []byte {
 	for i, s := range str {

--- a/core/util/bytes.go
+++ b/core/util/bytes.go
@@ -236,18 +236,33 @@ func ToBytes(s string) (uint64, error) {
 
 /** https://github.com/cloudfoundry/bytefmt/blob/master/bytes.go end **/
 
+// BytesToStringUnsafe returns a string pointing to the byte slice's underlying data.
+// This is EXTREMELY UNSAFE and should only be used when the byte slice is guaranteed
+// to be immutable and its lifetime is longer than the returned string.
+//
+// The returned string MUST NOT be modified, and the byte slice MUST NOT be modified
+// after the string is created.
 func UnsafeBytesToString(bs []byte) string {
-	return *(*string)(unsafe.Pointer(&bs))
+	// Ensure the byte slice 'bs' is not modified after calling this function!
+	// Ensure the lifetime of 'bs' is longer than the returned string!
+
+	return unsafe.String(unsafe.SliceData(bs), len(bs))
 }
 
+// StringToBytesUnsafe returns a byte slice pointing to the string's underlying data.
+// This is UNSAFE and should only be used for read-only access and when the
+// string's lifetime is guaranteed to be longer than the returned slice.
+//
+// The returned slice MUST NOT be modified.
 func UnsafeStringToBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(&s))
-}
-
-func UnsafeGetStringToBytes(s string) []byte {
+	// The string 's' must remain alive for the lifetime of the returned slice.
+	// The compiler *should* prevent 's' from being GC'd while the slice is in use,
+	// but it's best to ensure 's' is used in some way after this function call,
+	// to guarantee it's still reachable.
 	if len(s) == 0 {
 		return []byte{} // Handle empty string case to avoid nil slice
 	}
+	// This is the unsafe conversion, use with caution!
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 

--- a/core/util/bytes.go
+++ b/core/util/bytes.go
@@ -236,34 +236,12 @@ func ToBytes(s string) (uint64, error) {
 
 /** https://github.com/cloudfoundry/bytefmt/blob/master/bytes.go end **/
 
-// BytesToStringUnsafe returns a string pointing to the byte slice's underlying data.
-// This is EXTREMELY UNSAFE and should only be used when the byte slice is guaranteed
-// to be immutable and its lifetime is longer than the returned string.
-//
-// The returned string MUST NOT be modified, and the byte slice MUST NOT be modified
-// after the string is created.
 func UnsafeBytesToString(bs []byte) string {
-	// Ensure the byte slice 'bs' is not modified after calling this function!
-	// Ensure the lifetime of 'bs' is longer than the returned string!
-
-	return unsafe.String(unsafe.SliceData(bs), len(bs))
+	return *(*string)(unsafe.Pointer(&bs))
 }
 
-// StringToBytesUnsafe returns a byte slice pointing to the string's underlying data.
-// This is UNSAFE and should only be used for read-only access and when the
-// string's lifetime is guaranteed to be longer than the returned slice.
-//
-// The returned slice MUST NOT be modified.
 func UnsafeStringToBytes(s string) []byte {
-	// The string 's' must remain alive for the lifetime of the returned slice.
-	// The compiler *should* prevent 's' from being GC'd while the slice is in use,
-	// but it's best to ensure 's' is used in some way after this function call,
-	// to guarantee it's still reachable.
-	if len(s) == 0 {
-		return []byte{} // Handle empty string case to avoid nil slice
-	}
-	// This is the unsafe conversion, use with caution!
-	return unsafe.Slice(unsafe.StringData(s), len(s))
+	return *(*[]byte)(unsafe.Pointer(&s))
 }
 
 // ToLowercase convert string bytes to lowercase

--- a/core/util/bytes_test.go
+++ b/core/util/bytes_test.go
@@ -43,12 +43,101 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnsafeStringToBytes(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		expect []byte
+	}{
+		{
+			name:   "Non-empty string",
+			input:  "hello world",
+			expect: []byte("hello world"),
+		},
+		{
+			name:   "Empty string",
+			input:  "",
+			expect: []byte{},
+		},
+		{
+			name:   "String with special characters",
+			input:  "~!@#$%^&*()_+=-`",
+			expect: []byte("~!@#$%^&*()_+=-`"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := UnsafeStringToBytes(tc.input)
+
+			// DeepEqual is necessary because we are comparing slices
+			if !reflect.DeepEqual(result, tc.expect) {
+				t.Errorf("UnsafeStringToBytes(%q) = %q, expected %q", tc.input, result, tc.expect)
+			}
+
+			// *** IMPORTANT: DO NOT MODIFY THE RESULT SLICE OR THE INPUT STRING AFTER THIS POINT! ***
+		})
+	}
+}
+
+func TestUnsafeBytesToString(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  []byte
+		expect string
+	}{
+		{
+			name:   "Non-empty byte slice",
+			input:  []byte("hello world"),
+			expect: "hello world",
+		},
+		{
+			name:   "Empty byte slice",
+			input:  []byte{},
+			expect: "",
+		},
+		{
+			name:   "Byte slice with special characters",
+			input:  []byte("~!@#$%^&*()_+=-`"),
+			expect: "~!@#$%^&*()_+=-`",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := UnsafeBytesToString(tc.input)
+
+			if result != tc.expect {
+				t.Errorf("UnsafeBytesToString(%q) = %q, expected %q", tc.input, result, tc.expect)
+			}
+
+			// *** IMPORTANT: DO NOT MODIFY THE RESULT STRING OR THE INPUT BYTE SLICE AFTER THIS POINT! ***
+		})
+	}
+}
+
+// This test demonstrates the dangers of modifying the byte slice after creating the string
+func TestUnsafeBytesToStringMutation(t *testing.T) {
+	bs := []byte("initial")
+	str := UnsafeBytesToString(bs)
+
+	// This will modify the string!
+	bs[0] = 'M'
+
+	if str != "Mnitial" {
+		t.Errorf("String was not mutated as expected! str = %q", str)
+	}
+
+	// VERY IMPORTANT: this can lead to crashes, data corruption and undefined behavior
+}
 
 var splitBytes = []byte("\",")
 var searchLen = len(splitBytes)

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,7 +14,7 @@ Information about release notes of INFINI Framework is provided here.
 ### Features
 
 ### Bug fix
-- Fixed `UnsafeStringToBytes` and `UnsafeBytesToString` functions (#77)
+- Fixed `[]byte` operator paic (#77)
 
 ### Improvements
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,6 +14,7 @@ Information about release notes of INFINI Framework is provided here.
 ### Features
 
 ### Bug fix
+- Fixed `UnsafeStringToBytes` and `UnsafeBytesToString` functions (#77)
 
 ### Improvements
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,9 +14,11 @@ Information about release notes of INFINI Framework is provided here.
 ### Features
 
 ### Bug fix
-- Fixed `[]byte` operator paic (#77)
+- Fixed `[]byte` operator when queue comsumer paic (#77)
 
 ### Improvements
+
+- Add debug message for `queue` comsumer (#77)
 
 ## v1.1.1 (2025-01-24)
 

--- a/modules/queue/disk_queue/cleanup.go
+++ b/modules/queue/disk_queue/cleanup.go
@@ -142,7 +142,7 @@ func (module *DiskQueue) deleteUnusedFiles(queueID string, fileNum int64) {
 			var exists = false
 			if util.FileExists(file) {
 				exists = true
-				log.Debug("delete queue file:", file)
+				log.Trace("delete queue file:", file)
 				err := os.Remove(file)
 				if err != nil {
 					log.Error(err)

--- a/modules/queue/disk_queue/consumer.go
+++ b/modules/queue/disk_queue/consumer.go
@@ -202,15 +202,17 @@ READ_MSG:
 					oldPart := d.segment
 					Notify(d.queue, ReadComplete, d.segment)
 					ctx.UpdateNextOffset(d.segment, d.readPos) //update next offset
-					log.Debugf("EOF, but current read segment_id [%v] is less than current write segment_id [%v], increase ++", oldPart, d.segment)
+					log.Debugf("EOF, but current read segment_id [%v] is less than current write segment_id [%v], increase ++", oldPart, d.diskQueue.writeSegmentNum)
 					err = d.ResetOffset(d.segment+1, 0) //locate next segment
 					if err != nil {
 						if strings.Contains(err.Error(), "not found") {
 							return messages, false, nil
 						}
+						log.Errorf("queue:%v,offset:%v,%v, invalid message size: %v, should between: %v TO %v, error: %v", d.queue, d.segment, d.readPos, msgSize, d.mCfg.MinMsgSize, d.mCfg.MaxMsgSize, err)
 						panic(err)
 					}
 					ctx.UpdateNextOffset(d.segment, d.readPos)
+
 					return messages, false, err
 				}
 
@@ -247,7 +249,7 @@ READ_MSG:
 				nextSegment := d.segment + 1
 			RETRY_NEXT_FILE:
 				nextFile, exists, _ := SmartGetFileName(d.mCfg, d.queue, nextSegment)
-				log.Debugf("try skip to next file: %v, exists: %v", nextFile, exists)
+				log.Debugf("retry skip to next file: %v, exists: %v", nextFile, exists)
 				if exists || util.FileExists(nextFile) {
 					//update offset
 					err = d.ResetOffset(nextSegment, 0)
@@ -256,6 +258,7 @@ READ_MSG:
 						if strings.Contains(err.Error(), "not found") {
 							return messages, false, nil
 						}
+						log.Errorf("queue:%v,offset:%v,%v, invalid message size: %v, should between: %v TO %v, error: %v", d.queue, d.segment, d.readPos, msgSize, d.mCfg.MinMsgSize, d.mCfg.MaxMsgSize, err)
 						panic(err)
 					}
 					ctx.UpdateNextOffset(nextSegment, 0)
@@ -264,13 +267,13 @@ READ_MSG:
 				} else {
 					//can't read ahead before current write file
 					if nextSegment >= d.diskQueue.writeSegmentNum {
-						log.Errorf("need to skip to next file, but next file not exists, current write segment:%v, current read segment:%v", d.diskQueue.writeSegmentNum, d.segment)
+						log.Debugf("need to skip to next file, but next file not exists, current write segment:%v, current read segment:%v", d.diskQueue.writeSegmentNum, d.segment)
 						d.diskQueue.skipToNextRWFile(false)
 						d.diskQueue.needSync = true
 					} else {
 						//let's continue move to next file
 						nextSegment++
-						log.Debugf("move to next file: %v", nextSegment)
+						log.Debugf("fetch messages move to next file: %v", nextSegment)
 						goto RETRY_NEXT_FILE
 					}
 
@@ -374,7 +377,9 @@ READ_MSG:
 	}
 
 RELOAD_FILE:
-	log.Debugf("load queue file: %v/%v, read at: %v", d.queue, d.segment, d.readPos)
+	if global.Env().IsDebug {
+		log.Debugf("load queue file: %v/%v, read at: %v", d.queue, d.segment, d.readPos)
+	}
 	if nextReadPos >= d.maxBytesPerFileRead {
 
 		if !d.fileLoadCompleted {
@@ -503,15 +508,15 @@ func (d *Consumer) ResetOffset(segment, readPos int64) error {
 				// there are segments in the middle
 				if nextSegment < d.diskQueue.writeSegmentNum {
 					fileName, exists, next_file_exists = SmartGetFileName(d.mCfg, d.queue, nextSegment)
-					log.Debugf("try skip to next file: %v, exists: %v", fileName, exists)
 					if exists || util.FileExists(fileName) {
+						log.Debugf("retry skip to next file: %v, exists", fileName)
 						d.segment = nextSegment
 						d.readPos = 0
 						d.diskQueue.UpdateSegmentConsumerInReading(d.ID, d.segment)
 						goto FIND_NEXT_FILE
 					} else {
 						nextSegment++
-						log.Debugf("move to next file: %v", nextSegment)
+						log.Debugf("retry skip to next file: %v, not exists", fileName)
 						goto RETRY_NEXT_FILE
 					}
 				} else {

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -676,7 +676,7 @@ func saveOffset(k *queue.QueueConfig, consumer *queue.ConsumerConfig, offset que
 		}
 	}
 
-	err = kv.AddValue(ConsumerOffsetBucket, util.UnsafeStringToBytes(getCommitKey(k, consumer)), []byte(offset.EncodeToString()))
+	err = kv.AddValue(ConsumerOffsetBucket, []byte(getCommitKey(k, consumer)), []byte(offset.EncodeToString()))
 	if err != nil {
 		return false, err
 	}

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -676,7 +676,7 @@ func saveOffset(k *queue.QueueConfig, consumer *queue.ConsumerConfig, offset que
 		}
 	}
 
-	err = kv.AddValue(ConsumerOffsetBucket, util.UnsafeGetStringToBytes(getCommitKey(k, consumer)), []byte(offset.EncodeToString()))
+	err = kv.AddValue(ConsumerOffsetBucket, util.UnsafeStringToBytes(getCommitKey(k, consumer)), []byte(offset.EncodeToString()))
 	if err != nil {
 		return false, err
 	}

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -676,9 +676,7 @@ func saveOffset(k *queue.QueueConfig, consumer *queue.ConsumerConfig, offset que
 		}
 	}
 
-	//log.Debugf("save offset: %v", offset.EncodeToString())
-
-	err = kv.AddValue(ConsumerOffsetBucket, util.UnsafeStringToBytes(getCommitKey(k, consumer)), []byte(offset.EncodeToString()))
+	err = kv.AddValue(ConsumerOffsetBucket, util.UnsafeGetStringToBytes(getCommitKey(k, consumer)), []byte(offset.EncodeToString()))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## What does this PR do
This pull request includes several updates and improvements across multiple files. The changes primarily involve enhancing logging messages for better clarity, adding error handling, and updating function implementations. Below are the most important changes grouped by theme:

### Logging Improvements:
* Updated various logging messages in `modules/queue/disk_queue/consumer.go` to include more detailed information, such as `workerID`. This improves traceability and debugging. [[1]](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2L205-R215) [[2]](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2L250-R252) [[3]](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2R261) [[4]](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2L267-R276) [[5]](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2R380-R382) [[6]](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2L506-R519)
* Enhanced logging in `plugins/elastic/bulk_indexing/bulk_indexing.go` to provide more context by including the `workerID` in log messages. This helps in identifying the specific worker handling the task. [[1]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L574-R579) [[2]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L643-R643) [[3]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L717-R717) [[4]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L749-R761) [[5]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L776-R780) [[6]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L789-L803) [[7]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L814-R814) [[8]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L877-R876) [[9]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L913-R921) [[10]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L947-R962) [[11]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L983-R971) [[12]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L994-R982)

### Error Handling:
* Added error logging for invalid message sizes in `modules/queue/disk_queue/consumer.go` to provide more detailed error messages when encountering issues with message sizes. [[1]](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2L205-R215) [[2]](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2R261)

### Function Implementations:
* Introduced a new function `UnsafeGetStringToBytes` in `core/util/bytes.go` to handle empty string cases and avoid nil slices. This function provides a safer alternative for converting strings to bytes.
* Replaced the usage of `UnsafeStringToBytes` with `UnsafeGetStringToBytes` in `modules/queue/disk_queue/module.go` to ensure the safer handling of string-to-byte conversions.

### Typographical Fixes:
* Corrected a typo in the function name from `getElasticsearchMeatadata` to `getElasticsearchMetadata` in `plugins/elastic/bulk_indexing/bulk_indexing.go`. [[1]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L353-R353) [[2]](diffhunk://#diff-6342091b7f8deb108538e68b24a4a9999298f0508417e62b08e1b30c6deade49L682-R703)

These changes collectively improve the robustness, clarity, and maintainability of the codebase.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation