### PR TITLE
fix: reload file need use privious pos

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,8 @@ Information about release notes of INFINI Framework is provided here.
 
 ### Bug fix
 
+- Fixed reload file need use privious pos (#79)
+
 ### Improvements
 
 ## v1.1.1 (2025-01-24)

--- a/modules/queue/disk_queue/consumer.go
+++ b/modules/queue/disk_queue/consumer.go
@@ -328,6 +328,7 @@ READ_MSG:
 				log.Debugf("invalid message size detected. this might be due to a partial file load. reloading segment: %d", d.segment)
 			}
 
+			d.readPos = previousPos
 			stats.Increment("consumer", d.qCfg.ID, d.cCfg.ID, "reload_partial_file")
 			goto RELOAD_FILE
 		}


### PR DESCRIPTION
## What does this PR do
This pull request includes a small but important change to the `modules/queue/disk_queue/consumer.go` file. The change ensures that the read position is reset to the previous position when an invalid message size is detected, which helps to handle partial file loads more gracefully.

* [`modules/queue/disk_queue/consumer.go`](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2R331): Added a line to reset `d.readPos` to `previousPos` when an invalid message size is detected, improving the handling of partial file loads.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation