### PR TITLE
chore: fix path walk warn when tmp rename

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,10 +15,10 @@ Information about release notes of INFINI Framework is provided here.
 
 ### Bug fix
 - Fixed `[]byte` operator when queue comsumer paic (#77)
-- Fix incorrect interval configuration in index stats collection task (#80)
+- Fixed incorrect interval configuration in index stats collection task (#80)
 - Fixed reload file need use privious pos (#79)
 - Fixed nil panic by init cluster health default status to green (#81) 
-
+- Fixed path walk warn when tmp rename (#82)
 
 ### Improvements
 

--- a/lib/status/path.go
+++ b/lib/status/path.go
@@ -5,13 +5,14 @@
 package status
 
 import (
-	"infini.sh/framework/core/errors"
-	"infini.sh/framework/core/global"
-	"infini.sh/framework/core/util"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"infini.sh/framework/core/errors"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/util"
 )
 
 // DiskFsType represents the type of a file system.
@@ -33,15 +34,21 @@ type DiskFs struct {
 
 func DirSize(path string) (uint64, error) {
 	var size int64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+	err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			if filePath == path {
+				return err
+			}
+			// continue to walk the directory and ignore the error
+			return nil
 		}
+
 		if !info.IsDir() {
 			size += info.Size()
 		}
-		return err
+		return nil
 	})
+
 	return uint64(size), err
 }
 


### PR DESCRIPTION
## What does this PR do
This pull request includes changes to the `lib/status/path.go` file to improve error handling and code readability. The most important changes include reordering imports and modifying the `DirSize` function to handle errors more gracefully.

Improvements to error handling and code readability:

* [`lib/status/path.go`](diffhunk://#diff-ee7113bebdbeff52f1a98a8291584f8af19b01798d158a6c4217d7e9776b2656L8-R15): Reordered imports to follow Go conventions.
* [`lib/status/path.go`](diffhunk://#diff-ee7113bebdbeff52f1a98a8291584f8af19b01798d158a6c4217d7e9776b2656L36-R51): Modified the `DirSize` function to continue walking the directory and ignore errors for non-root paths, improving robustness.
## Rationale for this change
![image](https://github.com/user-attachments/assets/9307abdb-f887-40ae-8254-b0edde24094f)

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation