### PR TITLE
fix: comsumer segment without producer

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -17,6 +17,7 @@ Information about release notes of INFINI Framework is provided here.
 - Add utility to securely marshal JSON (#85)
 
 ### Bug fix
+- Fixed comsumer segment without producer (#89)
 
 ### Improvements
 - Structure http error response (#86)

--- a/modules/queue/disk_queue/consumer.go
+++ b/modules/queue/disk_queue/consumer.go
@@ -142,6 +142,10 @@ READ_MSG:
 		}
 	}
 
+	// check reader
+	if d.reader == nil {
+		return messages, false, errors.New("reader is nil")
+	}
 	//read message size
 	err = binary.Read(d.reader, binary.BigEndian, &msgSize)
 	if err != nil {
@@ -344,7 +348,7 @@ READ_MSG:
 			}
 			newData, err := zstd.ZSTDDecompress(nil, readBuf)
 			if err != nil {
-				log.Error(err)
+				log.Errorf("decompress message error: %v %v,%v %v", d.fileName, d.segment, d.readPos, err)
 				ctx.UpdateNextOffset(d.segment, nextReadPos)
 				return messages, false, err
 			}

--- a/modules/queue/disk_queue/consumer.go
+++ b/modules/queue/disk_queue/consumer.go
@@ -467,6 +467,11 @@ func (d *Consumer) ResetOffset(segment, readPos int64) error {
 		log.Debugf("reset offset: %v,%v, file: %v, queue:%v", segment, readPos, d.fileName, d.queue)
 	}
 
+	// no producer write data to this queue
+	if d.diskQueue.writeSegmentNum == 0 && d.diskQueue.writePos == 0 {
+		return nil
+	}
+
 	if segment > d.diskQueue.writeSegmentNum {
 		log.Errorf("reading segment [%v] is greater than writing segment [%v]", segment, d.diskQueue.writeSegmentNum)
 		return io.EOF

--- a/modules/queue/disk_queue/diskqueue.go
+++ b/modules/queue/disk_queue/diskqueue.go
@@ -504,6 +504,7 @@ func (d *DiskBasedQueue) readOne() ([]byte, error) {
 		}
 		newData, err := zstd.ZSTDDecompress(nil, readBuf)
 		if err != nil {
+			log.Errorf("diskqueue(%s) failed to decompress %v,%v - %s", d.name, d.readSegmentFileNum, d.readPos)
 			return nil, err
 		}
 		return newData, nil
@@ -552,6 +553,7 @@ func (d *DiskBasedQueue) writeOne(data []byte) WriteResponse {
 		}
 		newData, err := zstd.ZSTDCompress(nil, data, d.cfg.Compress.Message.Level)
 		if err != nil {
+			log.Errorf("diskqueue(%s) failed to compress %v,%v - %s", d.name, d.readSegmentFileNum, d.readPos)
 			res.Error = err
 			return res
 		}

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -374,6 +374,10 @@ func (module *DiskQueue) AcquireConsumer(qconfig *queue.QueueConfig, consumer *q
 	}
 	if ok {
 		q1 := q.(*DiskBasedQueue)
+		if q1.writeSegmentNum == 0 && q1.writePos == 0 {
+			//empty queue, no need to create consumer
+			return nil, errors.New("empty queue")
+		}
 		return q1.AcquireConsumer(qconfig, consumer, offset)
 	}
 	panic(errors.Errorf("queue [%v] not found", qconfig.Name))

--- a/plugins/queue/consumer/consumer.go
+++ b/plugins/queue/consumer/consumer.go
@@ -485,8 +485,10 @@ func (processor *QueueConsumerProcessor) NewSlicedWorker(ctx *pipeline.Context, 
 				case string:
 					v = r.(string)
 				}
-				log.Errorf("worker[%v], queue:[%v], slice:[%v], offset:[%v]->[%v],%v", workerID, qConfig.ID, sliceID, initOffset, offset, v)
-				ctx.Failed(fmt.Errorf("panic in slice worker: %+v", r))
+				if v != "empty queue" {
+					log.Errorf("worker[%v], queue:[%v], slice:[%v], offset:[%v]->[%v],%v", workerID, qConfig.ID, sliceID, initOffset, offset, v)
+					ctx.Failed(fmt.Errorf("panic in slice worker: %+v", r))
+				}
 				if parentContext != nil {
 					parentContext.RecordError(fmt.Errorf("panic in slice worker: %+v", r))
 				}


### PR DESCRIPTION
## What does this PR do
This pull request includes several changes to improve error handling and add new checks in the disk queue consumer module. The most important changes include fixing a bug related to the consumer segment, adding checks for the reader and empty queues, and enhancing error logging.

### Bug Fixes and Improvements:

* [`docs/content.en/docs/release-notes/_index.md`](diffhunk://#diff-6a5ab1b382c7b8d732e1667c4b8b236b020871d8f02badb577c84a938e5826f5R20): Fixed consumer segment without producer issue.

### Error Handling Enhancements:

* [`modules/queue/disk_queue/consumer.go`](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2R145-R148): Added a check to ensure the reader is not nil before reading the message size.
* [`modules/queue/disk_queue/consumer.go`](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2L347-R351): Improved error logging for decompression errors by including additional context.
* [`modules/queue/disk_queue/consumer.go`](diffhunk://#diff-573abe7a34449f57e713a221e96c5b596978db9dc1e30804b808b3670f6b2ba2R474-R478): Added a check to handle cases where no producer has written data to the queue.

### Additional Checks:

* [`modules/queue/disk_queue/module.go`](diffhunk://#diff-c3da99497df501af4a377a5c681c100a85e4cd3d67bfb778d8a99e1e29a8d2daR377-R380): Added a check to prevent creating a consumer for an empty queue.
* [`plugins/queue/consumer/consumer.go`](diffhunk://#diff-ea538f3bb383490c261f0fa04ab969f07b5233b0ced7438a90e50cbf8ebcaccdR488-R491): Modified error handling to exclude "empty queue" errors from being logged as worker errors.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation