### PR TITLE
feat: add support for iterating over key-value buckets

### DIFF
--- a/core/kv/kv.go
+++ b/core/kv/kv.go
@@ -52,6 +52,10 @@ type KVStore interface {
 	//DeleteBucket(bucket string) error
 }
 
+type KVIterator interface {
+	Iterate(bucket string, iter func(k, v []byte) bool) error
+}
+
 var handler KVStore
 
 func getKVHandler() KVStore {
@@ -84,6 +88,17 @@ func ExistsKey(bucket string, key []byte) (bool, error) {
 
 func DeleteKey(bucket string, key []byte) error {
 	return getKVHandler().DeleteKey(bucket, key)
+}
+
+var ErrKVIteratorStop = errors.New("stop iteration")
+
+func Iterate(bucket string, iter func(k, v []byte) bool) error {
+	kvh := getKVHandler()
+	if kvIter, ok := kvh.(KVIterator); ok {
+		return kvIter.Iterate(bucket, iter)
+	}
+	//todo handle not support iterate
+	return nil
 }
 
 //func DeleteBucket(bucket string) error {

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,6 +14,7 @@ Information about release notes of INFINI Framework is provided here.
 - Add configuration option to disable echo messages during WebSocket connection #96
 - Allow to register callback on websocket's connect/disconnect #96
 - Add optional login feature flag to api
+- Add support for iterating over key-value buckets #100
 
 ### Bug fix  
 ### Improvements  

--- a/modules/elastic/store.go
+++ b/modules/elastic/store.go
@@ -150,3 +150,7 @@ func (store *ElasticStore) DeleteKey(bucket string, key []byte) error {
 func (store *ElasticStore) DeleteBucket(bucket string) error {
 	panic(errors.New("not implemented yet"))
 }
+
+func (filter *ElasticStore) Iterate(bucket string, iterFunc func(k, v []byte) bool) error {
+	panic(errors.New("not implemented yet"))
+}

--- a/plugins/badger/module_test.go
+++ b/plugins/badger/module_test.go
@@ -89,3 +89,24 @@ func run(seed int, t *testing.T) {
 	}
 	fmt.Println("done", seed)
 }
+
+func TestIterateBucket(t *testing.T) {
+	env1 := EmptyEnv()
+	env1.SystemConfig.PathConfig.Data = "/tmp/filter_" + util.PickRandomName()
+	os.RemoveAll(env1.SystemConfig.PathConfig.Data)
+	global.RegisterEnv(env1)
+
+	m := Module{}
+	m.Setup()
+	m.Start()
+	for i := 0; i < 10; i++ {
+		m.Add(filterKey, []byte(fmt.Sprintf("key-%v", i)))
+	}
+	var keyCount int
+	err := m.Iterate(filterKey, func(k, v []byte) bool {
+		keyCount++
+		return true
+	})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 10, keyCount)
+}


### PR DESCRIPTION
## What does this PR do
This pull request introduces a new iteration functionality to the key-value store interfaces and implementations. The most important changes include the addition of the `KVIterator` interface, the implementation of the `Iterate` method in various key-value store modules, and the handling of iteration errors.

### Key-Value Store Iteration:

* [`core/kv/kv.go`](diffhunk://#diff-6fbeb5c5b034ccc75797e70b5e2e90b30039ef40309835cac2b3aa2481876709R55-R58): Added a new `KVIterator` interface with the `Iterate` method and defined the `ErrKVIteratorStop` error for stopping iteration. Implemented the `Iterate` function to check if the key-value handler supports iteration and call the appropriate method. [[1]](diffhunk://#diff-6fbeb5c5b034ccc75797e70b5e2e90b30039ef40309835cac2b3aa2481876709R55-R58) [[2]](diffhunk://#diff-6fbeb5c5b034ccc75797e70b5e2e90b30039ef40309835cac2b3aa2481876709R93-R103)

### ElasticStore Module:

* [`modules/elastic/store.go`](diffhunk://#diff-7ae7783c8d8144315ab16d21d9942f2c4fde1a3d226d98e69b9eb20764bd1380R153-R156): Added a placeholder `Iterate` method to the `ElasticStore` struct, which currently panics with a "not implemented yet" error.

### Badger Module:

* [`plugins/badger/badger.go`](diffhunk://#diff-ec4fa4debf04f2660a29613999e1f26909b96babdfdf8a960dd457b57621ecc8R314-R349): Implemented the `Iterate` method for the `Module` struct, ensuring the provided iteration function is not nil and handling module closure. The method uses a read-only transaction to iterate over the bucket and calls the iteration function for each key-value pair.

### SimpleKV Module:

* [`plugins/simple_kv/simple.go`](diffhunk://#diff-88a7dd4a7b2a19bb738990756296facd6fe4f8c4fed06ed6b4ed3d1e7fe0f6f6R141-R160): Implemented the `Iterate` method for the `SimpleKV` struct, handling module closure and iterating over the key-value store data while copying values to avoid referencing internal memory.

### Import Adjustments:

* `plugins/badger/badger.go` and `plugins/simple_kv/simple.go`: Added imports for the `kv` package to access the new `KVIterator` interface and iteration error. [[1]](diffhunk://#diff-ec4fa4debf04f2660a29613999e1f26909b96babdfdf8a960dd457b57621ecc8R32) [[2]](diffhunk://#diff-88a7dd4a7b2a19bb738990756296facd6fe4f8c4fed06ed6b4ed3d1e7fe0f6f6R32-R33)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation