### PR TITLE
fix: cluster init status loss when default setting is green

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,8 @@ Information about release notes of INFINI Framework is provided here.
 ### Breaking changes  
 ### Features  
 ### Bug fix  
+- fix: cluster init status loss when default setting is green
+
 ### Improvements  
 - Refactoring elasticsearch error base
 - chore: no panic during redis start

--- a/modules/elastic/metadata.go
+++ b/modules/elastic/metadata.go
@@ -77,7 +77,7 @@ func (module *ElasticModule) clusterHealthCheck(clusterID string, force bool) {
 				updateClusterHealthStatus(clusterID, "unavailable")
 			}
 		} else {
-			if metadata.Health == nil || metadata.Health.Status != health.Status || !metadata.IsAvailable() {
+			if metadata.Health == nil || metadata.Health.Status != health.Status || !metadata.IsAvailable() || force {
 				if metadata.Config.Source == elastic.ElasticsearchConfigSourceElasticsearch {
 					updateClusterHealthStatus(clusterID, health.Status)
 				}


### PR DESCRIPTION
## What does this PR do
This pull request includes a change to the `clusterHealthCheck` function in the `modules/elastic/metadata.go` file. The change introduces an additional condition to the health check logic.

Modification to health check logic:

* [`modules/elastic/metadata.go`](diffhunk://#diff-f544072235bcb59af61377c05c77fd5adf657a7e7c2e666d8103901c220324f6L80-R80): Added a `force` parameter check to the condition that updates the cluster health status. This ensures that the health status is updated even if the cluster is available but the `force` parameter is set to true.
## Rationale for this change
(#81)
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation