### PR TITLE
chore: add util to access api feature option

### DIFF
--- a/core/api/options.go
+++ b/core/api/options.go
@@ -138,3 +138,13 @@ func Feature(feature string) Option {
 		o.Features[feature] = true
 	}
 }
+
+func (option *HandlerOptions)Feature(feature string) bool {
+	if option.Features!=nil{
+		v,ok:=option.Features[feature]
+		if ok{
+			return v
+		}
+	}
+	return false
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -24,6 +24,7 @@ Information about release notes of INFINI Framework is provided here.
 - chore: lower priority filter should execute first
 - chore: refactory permission options to array
 - chore: add support for converting floats in InterfaceToInt
+- chore: add util to access api feature option
 
 ## 1.1.4 (2025-03-14)
 ### Breaking changes  


### PR DESCRIPTION
## What does this PR do

How to add your feature like this:


```

package filter

import (
	log "github.com/cihub/seelog"
	"infini.sh/framework/core/api"
	httprouter "infini.sh/framework/core/api/router"
	"net/http"
)

func init() {
	api.RegisterUIFilter(&XXXFilter{})
}

type XXXFilter struct {
	api.Handler
}

func (f *XXXFilter) GetPriority() int {
	return 100
}

const FeatureXXX = "feature_XXXX"

func (f *XXXFilter) ApplyFilter(
	method string,
	pattern string,
	options *api.HandlerOptions,
	next httprouter.Handle,
) httprouter.Handle {

	//option not enabled
	if options == nil || !options.Feature(FeatureXXX) {
		log.Debug(method, ",", pattern, ",skip feature xxx")
		return next
	}

	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
		
		//APPLY your filter here

		next(w, r, ps)
	}
}

```

Assign this feature to specify API:
```
	api.HandleUIMethod(api.POST, "/xxxx", apiHandler.xxxx, api.Feature("feature_XXXX"))

```


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation