### PR TITLE
chore: set service restart policy to always

### DIFF
--- a/app.go
+++ b/app.go
@@ -570,6 +570,7 @@ func (app *App) Run() {
 	//init service
 	svcOptions := make(service.KeyValue)
 	svcOptions["Restart"] = "always"
+	svcOptions["RestartSec"] = 120
 	svcOptions["SuccessExitStatus"] = "1 2 8 SIGKILL"
 	svcOptions["LimitNOFILE"] = 1024000
 

--- a/app.go
+++ b/app.go
@@ -569,7 +569,7 @@ func (app *App) Run() {
 
 	//init service
 	svcOptions := make(service.KeyValue)
-	svcOptions["Restart"] = "on-success"
+	svcOptions["Restart"] = "always"
 	svcOptions["SuccessExitStatus"] = "1 2 8 SIGKILL"
 	svcOptions["LimitNOFILE"] = 1024000
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -24,6 +24,7 @@ Information about release notes of INFINI Framework is provided here.
 - chore: add util to get instance id
 - chore: add util to delete session key
 - chore: update profile structs
+- chore: set service restart policy to always
 
 ## 1.1.5 (2025-03-31)
 ### Breaking changes  


### PR DESCRIPTION
## What does this PR do
This pull request includes a small but important change to the `app.go` file. The change modifies the service restart policy to ensure the service always restarts regardless of the exit status.

* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL572-R572): Changed the `svcOptions["Restart"]` value from `"on-success"` to `"always"` to ensure the service restarts under all circumstances.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation