### PR TITLE
fix: register cluster status loss when default setting is `green`

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,11 +15,11 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add compression support to HTTP processor
 - feat: allow to register callback after setup
 
-
 ### Bug fix  
 - fix: fix WriteHeader to prevent duplicate status code writes
 - fix: ensure 200 status code is set before writing response in HTTP handler
 - fix: reload and notify when pipeline config changes are detected
+- fix: register cluster status loss when default setting is `green`
 ### Improvements  
 - chore: add util to get instance id
 - chore: add util to delete session key

--- a/modules/elastic/metadata.go
+++ b/modules/elastic/metadata.go
@@ -77,7 +77,7 @@ func (module *ElasticModule) clusterHealthCheck(clusterID string, force bool) {
 				updateClusterHealthStatus(clusterID, "unavailable")
 			}
 		} else {
-			if metadata.Health == nil || metadata.Health.Status != health.Status || !metadata.IsAvailable() || force {
+			if metadata.Health == nil || metadata.Health.NumberOfNodes == 0 || metadata.Health.Status != health.Status || !metadata.IsAvailable() || force {
 				if metadata.Config.Source == elastic.ElasticsearchConfigSourceElasticsearch {
 					updateClusterHealthStatus(clusterID, health.Status)
 				}


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the release notes and a bug fix in the `ElasticModule`'s cluster health check function. The most important changes include adding a new bug fix entry to the release notes and refining the conditions for updating the cluster health status in the `ElasticModule`.

Updates to release notes:

* [`docs/content.en/docs/release-notes/_index.md`](diffhunk://#diff-6a5ab1b382c7b8d732e1667c4b8b236b020871d8f02badb577c84a938e5826f5L18-R22): Added a new bug fix entry to register cluster status loss when the default setting is `green`.

Bug fix in cluster health check:

* [`modules/elastic/metadata.go`](diffhunk://#diff-f544072235bcb59af61377c05c77fd5adf657a7e7c2e666d8103901c220324f6L80-R80): Refined the condition to update the cluster health status by checking if `metadata.Health.NumberOfNodes` is `0`.
## Rationale for this change
（#81）(#112)

![image](https://github.com/user-attachments/assets/6ec83ff3-167f-4649-ba88-916b18bac630)

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation