### PR TITLE
chore: add detailed logging to `DiskQueue` for better traceability

### DIFF
--- a/modules/metrics/elastic/elasticsearch.go
+++ b/modules/metrics/elastic/elasticsearch.go
@@ -217,7 +217,7 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 				}
 				err = m.CollectClusterHealth(k, v)
 				if err != nil {
-					log.Error(err)
+					log.Error("collect cluster health error: ", err)
 				}
 			},
 		}
@@ -241,7 +241,7 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 				}
 				err = m.CollectClusterState(k, v)
 				if err != nil {
-					log.Error(err)
+					log.Error("collect cluster state error: ", err)
 				}
 			},
 		}
@@ -534,7 +534,7 @@ func (m *ElasticsearchMetric) CollectClusterHealth(k string, v *elastic.Elastics
 
 	err = m.onSaveEvent(&item)
 	if err != nil {
-		return err
+		return fmt.Errorf("[%s] save cluster health error: %w", v.Config.Name, err)
 	}
 	for indexName, healthInfo := range indicesHealth {
 		item = event.Event{
@@ -556,7 +556,7 @@ func (m *ElasticsearchMetric) CollectClusterHealth(k string, v *elastic.Elastics
 		}
 		err = m.onSaveEvent(&item)
 		if err != nil {
-			return err
+			return fmt.Errorf("[%s] save index health error: %w", v.Config.Name, err)
 		}
 	}
 	return nil

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -222,7 +222,7 @@ func (module *DiskQueue) Setup() {
 		MinMsgSize:          1,
 		MaxMsgSize:          104857600,         //100MB
 		MaxBytesPerFile:     100 * 1024 * 1024, //100MB
-		WriteTimeoutInMS:    3000,              //3s
+		WriteTimeoutInMS:    1000,              //1s
 		EOFRetryDelayInMs:   500,
 		SyncEveryRecords:    1000,
 		SyncTimeoutInMS:     1000,

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -222,7 +222,7 @@ func (module *DiskQueue) Setup() {
 		MinMsgSize:          1,
 		MaxMsgSize:          104857600,         //100MB
 		MaxBytesPerFile:     100 * 1024 * 1024, //100MB
-		WriteTimeoutInMS:    1000,              //1s
+		WriteTimeoutInMS:    3000,              //3s
 		EOFRetryDelayInMs:   500,
 		SyncEveryRecords:    1000,
 		SyncTimeoutInMS:     1000,


### PR DESCRIPTION
## What does this PR do
This pull request improves error handling and logging in the `ElasticsearchMetric` and `DiskQueue` modules, as well as updates a configuration parameter in the `DiskQueue` module. The changes enhance debugging capabilities and make the system more robust against errors.

### Improvements to error handling and logging:

* [`modules/metrics/elastic/elasticsearch.go`](diffhunk://#diff-22f447a825424b74a7703ccf0b4e3f28778acd718ecb86664db68db3e1b9718aL220-R220): Enhanced error logging in `InitialCollectTask` by adding more descriptive messages for cluster health and state collection errors. [[1]](diffhunk://#diff-22f447a825424b74a7703ccf0b4e3f28778acd718ecb86664db68db3e1b9718aL220-R220) [[2]](diffhunk://#diff-22f447a825424b74a7703ccf0b4e3f28778acd718ecb86664db68db3e1b9718aL244-R244)
* [`modules/metrics/elastic/elasticsearch.go`](diffhunk://#diff-22f447a825424b74a7703ccf0b4e3f28778acd718ecb86664db68db3e1b9718aL537-R537): Improved error messages in `CollectClusterHealth` by including the cluster name in the error details when saving cluster health or index health fails. [[1]](diffhunk://#diff-22f447a825424b74a7703ccf0b4e3f28778acd718ecb86664db68db3e1b9718aL537-R537) [[2]](diffhunk://#diff-22f447a825424b74a7703ccf0b4e3f28778acd718ecb86664db68db3e1b9718aL559-R559)
* [`modules/queue/disk_queue/diskqueue.go`](diffhunk://#diff-efcbec5b71fadf983e8cac99694a38f5f087b6451b76ba89dc421c73b151bdd0L228-R242): Added specific handling for `context.DeadlineExceeded` and `context.Canceled` errors in the `Put` method, providing more detailed error messages for context-related failures.

### Configuration updates:

* [`modules/queue/disk_queue/module.go`](diffhunk://#diff-c3da99497df501af4a377a5c681c100a85e4cd3d67bfb778d8a99e1e29a8d2daL225-R225): Increased the `WriteTimeoutInMS` configuration parameter from 1 second to 3 seconds to allow more time for write operations to complete.
## Rationale for this change
![image](https://github.com/user-attachments/assets/5eac19c6-c278-4f6d-8ce8-0f5a9428bd9e)

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation