### PR TITLE
chore: change makefile for ci task

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -141,7 +141,7 @@ jobs:
                 # for products
                 for p in console gateway agent loadgen; do
                   cd $WORK/$p && echo Compiling $p at $PWD ...
-                  OFFLINE_BUILD=true make build
+                  OFFLINE_BUILD=true GOMODULE=false make build
                 done
 
             - name: Prepare console config

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -56,4 +56,4 @@ jobs:
                 # for unit test
                 cd $WORK
                 echo Testing code at $PWD ...
-                OFFLINE_BUILD=true CI=true make test
+                OFFLINE_BUILD=true GOMODULE=false CI=true make test


### PR DESCRIPTION
## What does this PR do
This pull request introduces several updates and enhancements to the `Makefile`, focusing on improving build configurations, adding support for new platforms, and refining development workflows. The most significant changes include replacing hardcoded paths with environment variables, adding new build targets for multiple architectures, and introducing `test` and `lint` commands for better code quality checks.

### Build configuration improvements:
* Replaced hardcoded paths like `~/go` and `~/vfs` with the `$(HOME)` environment variable for better portability. (`[[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L26-R26)`, `[[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L39-R43)`)

### New build targets:
* Added new build targets for Linux (`armv6`, `armv7`, `mips64`, `mips64le`, `riscv64`), macOS (`amd64`, `arm64`), and Windows (`386`, `amd64`) to support a wider range of architectures. (`[[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L116-R124)`, `[[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L149-R186)`, `[[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R197-R213)`)

### Development workflow enhancements:
* Introduced `GOBUILDDEV` for development builds with specific flags and added `build-dev` and architecture-specific `build-linux-*` development targets. (`[[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L79-R80)`, `[[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L116-R124)`)
* Added `test` and `lint` commands to streamline testing and linting processes. (`[[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R256-R263)`, `[[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L335-L342)`)

### Cleanup and maintenance:
* Removed redundant or outdated build targets and commands, such as the `build-linux-amd64-dev` target and test/lint definitions in the `package-windows-platform` section. (`[[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L149-R186)`, `[[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L335-L342)`)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation