### PR TITLE
chore: refined development build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,10 @@ build: config
 	$(GOBUILD) -o $(OUTPUT_DIR)/$(APP_NAME)
 	@$(MAKE) restore-generated-file
 
+build-dev: config
+	$(GOBUILD) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-dev
+	@$(MAKE) restore-generated-file
+
 build-debug: config
 	$(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-debug
 	@$(MAKE) restore-generated-file

--- a/Makefile
+++ b/Makefile
@@ -112,18 +112,26 @@ build: config
 	$(GOBUILD) -o $(OUTPUT_DIR)/$(APP_NAME)
 	@$(MAKE) restore-generated-file
 
-build-dev: config
+build-debug: config
 	$(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)
 	@$(MAKE) restore-generated-file
 
-build-linux-amd64-dev: config
+build-linux-amd64-debug: config
 	GOOS=linux GOARCH=amd64 $(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-linux-amd64
 	@$(MAKE) restore-generated-file
 
-build-linux-arm64-dev: config
+build-linux-arm64-debug: config
 	GOOS=linux GOARCH=arm64 $(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64
 	@$(MAKE) restore-generated-file
 
+build-linux-amd64-dev: config
+	GOOS=linux  GOARCH=amd64 $(GOBUILD) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-linux-amd64-dev
+	@$(MAKE) restore-generated-file
+
+build-linux-arm64-dev: config
+	GOOS=linux  GOARCH=arm64 $(GOBUILD) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64-dev
+	@$(MAKE) restore-generated-file
+	
 build-cmd:
 	for f in $(shell ls ${CMD_DIR}); do (cd $(CMD_DIR)/$${f} && $(GOBUILD) -o $(OUTPUT_DIR)/$${f}); done
 	$(MAKE) restore-generated-file
@@ -185,7 +193,7 @@ build-linux-armv6: config
 build-linux-armv7: config
 	GOOS=linux  GOARCH=arm   GOARM=7    $(GOBUILD) -o $(OUTPUT_DIR)/$(APP_NAME)-linux-armv7
 	@$(MAKE) restore-generated-file
-
+	
 build-linux-arm64: config
 	GOOS=linux  GOARCH=arm64    $(GOBUILD) -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64
 	@$(MAKE) restore-generated-file

--- a/Makefile
+++ b/Makefile
@@ -113,15 +113,15 @@ build: config
 	@$(MAKE) restore-generated-file
 
 build-debug: config
-	$(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)
+	$(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-debug
 	@$(MAKE) restore-generated-file
 
 build-linux-amd64-debug: config
-	GOOS=linux GOARCH=amd64 $(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-linux-amd64
+	GOOS=linux GOARCH=amd64 $(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-linux-amd64-debug
 	@$(MAKE) restore-generated-file
 
 build-linux-arm64-debug: config
-	GOOS=linux GOARCH=arm64 $(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64
+	GOOS=linux GOARCH=arm64 $(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64-debug
 	@$(MAKE) restore-generated-file
 
 build-linux-amd64-dev: config

--- a/Makefile
+++ b/Makefile
@@ -129,13 +129,13 @@ build-linux-arm64-debug: config
 	@$(MAKE) restore-generated-file
 
 build-linux-amd64-dev: config
-	GOOS=linux  GOARCH=amd64 $(GOBUILD) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-linux-amd64-dev
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-linux-amd64-dev
 	@$(MAKE) restore-generated-file
 
 build-linux-arm64-dev: config
-	GOOS=linux  GOARCH=arm64 $(GOBUILD) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64-dev
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64-dev
 	@$(MAKE) restore-generated-file
-	
+
 build-cmd:
 	for f in $(shell ls ${CMD_DIR}); do (cd $(CMD_DIR)/$${f} && $(GOBUILD) -o $(OUTPUT_DIR)/$${f}); done
 	$(MAKE) restore-generated-file
@@ -197,7 +197,7 @@ build-linux-armv6: config
 build-linux-armv7: config
 	GOOS=linux  GOARCH=arm   GOARM=7    $(GOBUILD) -o $(OUTPUT_DIR)/$(APP_NAME)-linux-armv7
 	@$(MAKE) restore-generated-file
-	
+
 build-linux-arm64: config
 	GOOS=linux  GOARCH=arm64    $(GOBUILD) -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64
 	@$(MAKE) restore-generated-file

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ GOMODULE ?= true
 ifneq "$(GOMODULE)" "true"
     GO        := GO15VENDOREXPERIMENT="1" GO111MODULE=off go
 endif
-GOBUILD  := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) GRPC_GO_REQUIRE_HANDSHAKE=off  $(GO) build -a $(FRAMEWORK_DEVEL_BUILD) -gcflags=all="-l -B"  -ldflags '-static' -ldflags='-s -w' -gcflags "-m"  --work $(GOBUILD_FLAGS)
-GOBUILDDEV  := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) GRPC_GO_REQUIRE_HANDSHAKE=off  $(GO) build -a $(FRAMEWORK_DEVEL_BUILD) --work $(GOBUILD_FLAGS)
+GOBUILD  := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) GRPC_GO_REQUIRE_HANDSHAKE=off $(GO) build -a $(FRAMEWORK_DEVEL_BUILD) -gcflags=all="-l -B"  -ldflags '-static' -ldflags='-s -w' -gcflags "-m"  --work $(GOBUILD_FLAGS)
+GOBUILDDBG  := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) GRPC_GO_REQUIRE_HANDSHAKE=off $(GO) build -a $(FRAMEWORK_DEVEL_BUILD) -ldflags -v -gcflags "all=-N -l" --work $(GOBUILD_FLAGS)
 GOBUILDNCGO  := GOPATH=$(NEWGOPATH) CGO_ENABLED=1  $(GO) build -ldflags -s $(GOBUILD_FLAGS)
 GOTEST   := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) $(GO) test -ldflags -s
 GOLINT   := GOPATH=$(NEWGOPATH) CGO_ENABLED=$(APP_NEED_CGO) $(GO) vet -ldflags -s
@@ -117,15 +117,15 @@ build-dev: config
 	@$(MAKE) restore-generated-file
 
 build-debug: config
-	$(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-debug
+	$(GOBUILDDBG) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-debug
 	@$(MAKE) restore-generated-file
 
 build-linux-amd64-debug: config
-	GOOS=linux GOARCH=amd64 $(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-linux-amd64-debug
+	GOOS=linux GOARCH=amd64 $(GOBUILDDBG) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-linux-amd64-debug
 	@$(MAKE) restore-generated-file
 
 build-linux-arm64-debug: config
-	GOOS=linux GOARCH=arm64 $(GOBUILDDEV) -tags codes -ldflags -v -gcflags "all=-N -l" -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64-debug
+	GOOS=linux GOARCH=arm64 $(GOBUILDDBG) -tags dev -o $(OUTPUT_DIR)/$(APP_NAME)-linux-arm64-debug
 	@$(MAKE) restore-generated-file
 
 build-linux-amd64-dev: config


### PR DESCRIPTION
## What does this PR do
This pull request introduces changes to the `Makefile` to enhance build configurations by adding new debug build targets and refining existing development build targets. The most important changes focus on improving the flexibility and clarity of the build process for different environments and purposes.

### Build configuration updates:

* **Added a new debug build configuration (`GOBUILDDBG`)**: Introduced a new build command with debug-specific flags (`-N -l`) for better debugging support. This replaces the previous `GOBUILDDEV` configuration for debug purposes. (`Makefile`, [MakefileL80-R80](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L80-R80))

* **Added new debug build targets**: Introduced `build-debug`, `build-linux-amd64-debug`, and `build-linux-arm64-debug` targets to generate debug builds for local and platform-specific environments. These use the new `GOBUILDDBG` configuration. (`Makefile`, [MakefileL116-R136](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L116-R136))

* **Refined development build targets**: Updated `build-dev`, `build-linux-amd64-dev`, and `build-linux-arm64-dev` to use the `GOBUILD` configuration instead of the removed `GOBUILDDEV`, aligning them with the new build structure. (`Makefile`, [MakefileL116-R136](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L116-R136))
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation