### PR TITLE
chore: check capacity when disk queue module start

### DIFF
--- a/app.go
+++ b/app.go
@@ -309,6 +309,7 @@ func (app *App) Setup(setup func(), start func(), stop func()) (allowContinue bo
 	}
 
 	log.Infof("initializing %s, pid: %v", app.environment.GetAppName(), os.Getpid())
+	log.Infof("using data: %s", app.environment.GetDataDir())
 	log.Infof("using config: %s", app.environment.GetConfigFile())
 
 	//daemon

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -449,6 +449,11 @@ func (module *DiskQueue) Start() error {
 		return nil
 	}
 
+	err := checkCapacity(module.cfg)
+	if err != nil {
+		return err
+	}
+
 	//load configs from local file
 	if module.cfgs != nil {
 		for _, v := range module.cfgs {


### PR DESCRIPTION
## What does this PR do
This pull request introduces logging improvements and a new capacity check to enhance application monitoring and reliability. The changes focus on providing more detailed runtime information and ensuring proper resource allocation.

### Logging Improvements:
* Added a log statement in `app.go` to display the data directory being used by the application during initialization. This helps in debugging and understanding the runtime environment. (`[app.goR312](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR312)`)

### Reliability Enhancements:
* Introduced a capacity check in `module.go` for the `DiskQueue` module. The new `checkCapacity` function verifies resource availability before starting the module, returning an error if the check fails. This ensures that the module operates within safe limits. (`[modules/queue/disk_queue/module.goR452-R456](diffhunk://#diff-c3da99497df501af4a377a5c681c100a85e4cd3d67bfb778d8a99e1e29a8d2daR452-R456)`)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation