### PR TITLE
feat: support custom TLS minimum version for SMTP processor configuration

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,6 +11,7 @@ Information about release notes of INFINI Framework is provided here.
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- feat: support custom TLS minimum version for SMTP server configuration
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 


### PR DESCRIPTION
## What does this PR do
support custom TLS minimum version for SMTP processor configuration
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation