### PR TITLE
fix: wrong method call during ORM update

### DIFF
--- a/core/orm/orm.go
+++ b/core/orm/orm.go
@@ -472,7 +472,7 @@ func Update(ctx *Context, o interface{}) error {
 	t1 := time.Now()
 	setFieldValue(rValue, "Updated", &t1)
 
-	return Save(ctx, o)
+	return getHandler().Update(ctx, o)
 }
 
 func Delete(ctx *Context, o interface{}) error {

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: support custom TLS minimum version for SMTP server configuration
 
 ### 🐛 Bug fix
+- fix: wrong method call during ORM update
 ### ✈️ Improvements  
 - chore: check disk capacity when disk queue module start #136
 


### PR DESCRIPTION
## What does this PR do
fix wrong method call during ORM update
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation