### PR TITLE
fix: HTTP headers config was not applied with plugin `http`

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of INFINI Framework is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- fix: HTTP headers config was not applied with plugin `http`
 ### ✈️ Improvements  
 - refactor: refactoring query interface 
 - feat: url query support terms query #163

--- a/plugins/http/http.go
+++ b/plugins/http/http.go
@@ -31,6 +31,10 @@ package http
 
 import (
 	"fmt"
+	"io"
+	"strings"
+	"time"
+
 	log "github.com/cihub/seelog"
 	rate2 "golang.org/x/time/rate"
 	"infini.sh/framework/core/api"
@@ -45,9 +49,6 @@ import (
 	"infini.sh/framework/core/util"
 	"infini.sh/framework/lib/fasthttp"
 	"infini.sh/framework/lib/fasttemplate"
-	"io"
-	"strings"
-	"time"
 )
 
 // Default threshold in bytes to enable gzip compression if not configured
@@ -173,6 +174,9 @@ func (processor *HTTPProcessor) Process(ctx *pipeline.Context) error {
 			}
 			return -1, err
 		})
+	}
+	for key, value := range processor.config.Headers {
+		req.Header.Set(key, value)
 	}
 
 	uri := req.CloneURI()


### PR DESCRIPTION
## What does this PR do
fix HTTP headers config was not applied with plugin `http`
## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation