### PR TITLE
feat: add basic auth support to sync manager configuration

### DIFF
--- a/core/config/system.go
+++ b/core/config/system.go
@@ -25,9 +25,11 @@ package config
 
 import (
 	"fmt"
+	"strings"
+
 	"infini.sh/framework/core/errors"
 	"infini.sh/framework/core/util"
-	"strings"
+	"infini.sh/framework/lib/go-ucfg"
 )
 
 // ClusterConfig stores cluster settings
@@ -286,10 +288,17 @@ type ConfigsConfig struct {
 	TLSConfig                  TLSConfig `config:"tls"` //server or client's certs
 	ManagerConfig              struct {
 		LocalConfigsRepoPath string `config:"local_configs_repo_path"`
+		BasicAuth BasicAuth `config:"basic_auth"`
 	} `config:"manager"`
 	AlwaysRegisterAfterRestart bool     `config:"always_register_after_restart"`
 	AllowGeneratedMetricsTasks bool     `config:"allow_generated_metrics_tasks"`
 	IgnoredPath                []string `config:"ignored_path"`
+}
+
+type BasicAuth struct {
+	Username string `json:"username,omitempty" config:"username" elastic_mapping:"username:{type:keyword}"`
+	//password should not be logged, neither in json nor in log
+	Password ucfg.SecretString `json:"password,omitempty" config:"password" yaml:"password" elastic_mapping:"password:{type:keyword}"`
 }
 
 type ResourceLimit struct {

--- a/core/model/basic_auth.go
+++ b/core/model/basic_auth.go
@@ -28,11 +28,7 @@
 package model
 
 import (
-	"infini.sh/framework/lib/go-ucfg"
+	"infini.sh/framework/core/config"
 )
 
-type BasicAuth struct {
-	Username string `json:"username,omitempty" config:"username" elastic_mapping:"username:{type:keyword}"`
-	//password should not be logged, neither in json nor in log
-	Password ucfg.SecretString `json:"password,omitempty" config:"password" yaml:"password" elastic_mapping:"password:{type:keyword}"`
-}
+type BasicAuth config.BasicAuth

--- a/modules/configs/client/client.go
+++ b/modules/configs/client/client.go
@@ -30,6 +30,13 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/api"
 	"infini.sh/framework/core/errors"
@@ -41,12 +48,6 @@ import (
 	"infini.sh/framework/core/util"
 	"infini.sh/framework/modules/configs/common"
 	"infini.sh/framework/modules/configs/config"
-	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
-	"sync"
-	"time"
 )
 
 const bucketName = "instance_registered"
@@ -101,7 +102,11 @@ func ConnectToManager() error {
 func submitRequestToManager(req *util.Request) (string, *util.Result, error) {
 	var err error
 	var res *util.Result
-	for _, server := range global.Env().SystemConfig.Configs.Servers {
+	cfg := global.Env().SystemConfig.Configs
+	if cfg.ManagerConfig.BasicAuth.Username != "" {
+		req.SetBasicAuth(cfg.ManagerConfig.BasicAuth.Username, cfg.ManagerConfig.BasicAuth.Password.Get())
+	}
+	for _, server := range cfg.Servers {
 		req.Url, err = url.JoinPath(server, req.Path)
 		if err != nil {
 			continue


### PR DESCRIPTION
## What does this PR do
add basic auth support to sync manager configuration
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation