### PR TITLE
fix: support underscore '_' in quoted JSON keys

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 - fix: HTTP headers config was not applied with plugin `http`
+- fix: support underscore '_' in quoted JSON keys
 
 ### ✈️ Improvements  
 - refactor: refactoring query interface 

--- a/modules/elastic/schema.go
+++ b/modules/elastic/schema.go
@@ -30,15 +30,16 @@ package elastic
 import (
 	"bytes"
 	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"unicode"
+
 	"github.com/buger/jsonparser"
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/errors"
 	"infini.sh/framework/core/orm"
 	"infini.sh/framework/core/util"
-	"reflect"
-	"strings"
-	"sync"
-	"unicode"
 )
 
 var indexNames = sync.Map{}
@@ -192,6 +193,7 @@ var colon int32 = 58     //:
 var comma int32 = 44     //,
 var bracket1 int32 = 93  //]
 var bracket2 int32 = 125 //}
+var underscore int32 = 95 //_
 func quoteJson(str string) string {
 
 	var buffer bytes.Buffer
@@ -205,7 +207,7 @@ func quoteJson(str string) string {
 			quoted = false
 		}
 
-		if c != quote && unicode.IsLetter(c) && !quoted {
+		if c != quote && (unicode.IsLetter(c) || c == underscore) && !quoted {
 			buffer.WriteString("\"")
 			quoted = true
 		}

--- a/modules/elastic/schema_test.go
+++ b/modules/elastic/schema_test.go
@@ -25,9 +25,10 @@ package elastic
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/magiconair/properties/assert"
 	"infini.sh/framework/core/util"
-	"testing"
 )
 
 type Obj struct {
@@ -83,4 +84,10 @@ func TestGetDeepNesteIndexID(t *testing.T) {
 	tag := util.GetFieldValueByTagName(&o2, "elastic_meta", "_id")
 	fmt.Println(tag)
 	assert.Equal(t, tag, "myid3")
+}
+
+func TestQuoteWithUnderscore(t *testing.T) {
+	js := `{ properties:{ id: { type: keyword },created: { type: date },updated: { type: date },_system: { type: object },name: { type: keyword } } }`
+	json := quoteJson(js)
+	assert.Equal(t, json, `{ "properties":{ "id": { "type": "keyword" },"created": { "type": "date" },"updated": { "type": "date" },"_system": { "type": "object" },"name": { "type": "keyword" } } }`)
 }


### PR DESCRIPTION
## What does this PR do
support underscore '_' in quoted JSON keys
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation