### PR TITLE
feat: support aggregation queries in orm

### DIFF
--- a/core/orm/aggs_args_parser.go
+++ b/core/orm/aggs_args_parser.go
@@ -1,0 +1,252 @@
+package orm
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// keyPartRegex is used to parse keys like "agg[key1][key2]" into parts: "agg", "key1", "key2".
+var keyPartRegex = regexp.MustCompile(`^([^\[\]]+)|\[([^\[\]]*)\]`)
+
+
+// ParseAggregationsFromQuery takes URL query values and converts them into a map of abstract aggregations.
+func ParseAggregationsFromQuery(values url.Values) (map[string]Aggregation, error) {
+	// Step 1: Convert flat URL params into a nested map.
+	nestedMap, err := parseToNestedMap(values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL values to nested map: %w", err)
+	}
+
+	// Step 2: Convert the nested map into our abstract aggregator structs.
+	return buildAggregationsFromMap(nestedMap)
+}
+
+// parseToNestedMap converts flat url.Values with bracket notation into a nested map[string]interface{}.
+func parseToNestedMap(values url.Values) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+
+	for key, val := range values {
+		// We only care about keys starting with "agg".
+		if !strings.HasPrefix(key, "agg") {
+			continue
+		}
+
+		// Extract all parts from the key, e.g., "agg[types][terms][field]" -> ["agg", "types", "terms", "field"]
+		matches := keyPartRegex.FindAllStringSubmatch(key, -1)
+		var parts []string
+		for _, match := range matches {
+			var part string
+			if match[1] != "" {
+				part = match[1]
+			} else {
+				part = match[2]
+			}
+			
+			decodedPart, err := url.QueryUnescape(part)
+			if err != nil {
+				// Fallback to the raw part if decoding fails
+				decodedPart = part
+			}
+			parts = append(parts, decodedPart)
+		}
+		
+		if len(parts) == 0 || parts[0] != "agg" {
+			continue // Malformed key, skip.
+		}
+
+		// Navigate/create the nested map structure.
+		currentMap := result
+		for i, part := range parts[1:] { // Skip the "agg" prefix
+			// If it's the last part, assign the value.
+			if i == len(parts)-2 {
+				currentMap[part] = val[0] // Assume single value per key.
+				break
+			}
+
+			// If the next level map doesn't exist, create it.
+			if _, ok := currentMap[part]; !ok {
+				currentMap[part] = make(map[string]interface{})
+			}
+
+			// Move to the next level.
+			nextMap, ok := currentMap[part].(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("structure conflict in key '%s' at part '%s'", key, part)
+			}
+			currentMap = nextMap
+		}
+	}
+
+	return result, nil
+}
+
+// stringToNumberHook is a mapstructure.DecodeHookFunc that converts string representations
+// of numbers into actual numeric types (int, float64, etc.).
+func stringToNumberHook() mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+
+		// Special handling for comma-separated strings to []float64 for percentiles
+		if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Float64 {
+			str := data.(string)
+			parts := strings.Split(str, ",")
+			floats := make([]float64, 0, len(parts))
+			for _, part := range parts {
+				f, err := strconv.ParseFloat(strings.TrimSpace(part), 64)
+				if err != nil {
+					// If any part is not a float, let mapstructure handle it
+					return data, nil
+				}
+				floats = append(floats, f)
+			}
+			return floats, nil
+		}
+
+		// The target type must be a numeric type.
+		isNumeric := t.Kind() >= reflect.Int && t.Kind() <= reflect.Float64
+		if !isNumeric {
+			return data, nil
+		}
+		
+		str := data.(string)
+
+		// Try to parse as integer first.
+		if t.Kind() >= reflect.Int && t.Kind() <= reflect.Uint64 {
+			n, err := strconv.ParseInt(str, 10, 64)
+			if err == nil {
+				return n, nil
+			}
+		}
+
+		// Then try to parse as float.
+		if t.Kind() == reflect.Float32 || t.Kind() == reflect.Float64 {
+			f, err := strconv.ParseFloat(str, 64)
+			if err == nil {
+				return f, nil
+			}
+		}
+
+		// Return original data if parsing fails. Mapstructure will then report the error.
+		return data, nil
+	}
+}
+
+// decodeWithHooks is a helper function to decode a map into a struct using our custom hooks.
+func decodeWithHooks(input map[string]interface{}, result interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		// Add our custom hook function here.
+		DecodeHook: stringToNumberHook(),
+		Result:     result,
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(input)
+}
+
+// buildAggregationsFromMap is a recursive function that converts a map into Aggregation structs.
+func buildAggregationsFromMap(aggMap map[string]interface{}) (map[string]Aggregation, error) {
+	result := make(map[string]Aggregation)
+
+	for name, data := range aggMap {
+		dataMap, ok := data.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("aggregation '%s' has invalid format", name)
+		}
+
+		var agg Aggregation
+		var err error
+
+		// Aggregation Factory: determine the type and create the struct.
+		if termsData, ok := dataMap["terms"]; ok {
+			var termsAgg TermsAggregation
+			termsMap, ok := termsData.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("invalid format for terms aggregation '%s'", name)
+			}
+			if err = decodeWithHooks(termsMap, &termsAgg); err != nil {
+				return nil, fmt.Errorf("failed to decode terms aggregation '%s': %w", name, err)
+			}
+			agg = &termsAgg
+		} else if dateHistData, ok := dataMap["date_histogram"]; ok {
+			var dateHistAgg DateHistogramAggregation
+			dateHistMap, ok := dateHistData.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("invalid format for date_histogram aggregation '%s'", name)
+			}
+			if err = decodeWithHooks(dateHistMap, &dateHistAgg); err != nil {
+				return nil, fmt.Errorf("failed to decode date_histogram '%s': %w", name, err)
+			}
+			agg = &dateHistAgg
+		} else if percentilesData, ok := dataMap["percentiles"]; ok {
+			var percentilesAgg PercentilesAggregation
+			percentilesMap, ok := percentilesData.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("invalid format for percentiles aggregation '%s'", name)
+			}
+			if err = decodeWithHooks(percentilesMap, &percentilesAgg); err != nil {
+				return nil, fmt.Errorf("failed to decode percentiles aggregation '%s': %w", name, err)
+			}
+			agg = &percentilesAgg
+		} else {
+			// Handle various metric aggregations
+			var metricAgg *MetricAggregation
+			var metricType string
+
+			for key, metricData := range dataMap {
+				switch key {
+				case "avg", "sum", "min", "max", "cardinality":
+					if metricType != "" {
+						return nil, fmt.Errorf("aggregation '%s' has multiple metric types", name)
+					}
+					metricType = key
+					var m MetricAggregation
+					metricMap, ok := metricData.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf("invalid format for %s aggregation '%s'", key, name)
+					}
+					if err = decodeWithHooks(metricMap, &m); err != nil {
+						return nil, fmt.Errorf("failed to decode %s aggregation '%s': %w", key, name, err)
+					}
+					m.Type = key
+					metricAgg = &m
+				case "aggs":
+					// This will be handled later, after the metric agg is created.
+				default:
+					// Potentially unknown aggregation type in the same level as a metric.
+					// Depending on strictness, could be an error. For now, we ignore.
+				}
+			}
+
+			if metricAgg != nil {
+				agg = metricAgg
+			} else {
+				// Skip if no known aggregation type is found. Could also be an error.
+				continue
+			}
+		}
+
+		// Recursively build nested aggregations.
+		if nestedData, ok := dataMap["aggs"].(map[string]interface{}); ok {
+			nestedAggs, err := buildAggregationsFromMap(nestedData)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build nested aggregations for '%s': %w", name, err)
+			}
+			for subName, subAgg := range nestedAggs {
+				agg.AddNested(subName, subAgg)
+			}
+		}
+
+		result[name] = agg
+	}
+
+	return result, nil
+}

--- a/core/orm/aggs_args_parser_test.go
+++ b/core/orm/aggs_args_parser_test.go
@@ -1,0 +1,145 @@
+package orm
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestParseAggregationsFromQuery_SingleTerms(t *testing.T) {
+	// Arrange
+	rawURL := "http://example.com?agg[types][terms][field]=product.keyword&agg[types][terms][size]=5"
+	parsedURL, _ := url.Parse(rawURL)
+	
+	// Expected abstract structure
+	expected := map[string]Aggregation{
+		"types": &TermsAggregation{
+			Field: "product.keyword",
+			Size:  5,
+		},
+	}
+
+	// Act
+	result, err := ParseAggregationsFromQuery(parsedURL.Query())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("ParseAggregationsFromQuery returned an unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Resulting aggregation map does not match expected.\nGot: %#v\nWant: %#v", result, expected)
+	}
+}
+
+func TestParseAggregationsFromQuery_Nested(t *testing.T) {
+	// Arrange
+	rawURL := "http://example.com?agg[by_brand][terms][field]=brand&agg[by_brand][aggs][avg_price][avg][field]=price"
+	parsedURL, _ := url.Parse(rawURL)
+
+	// Expected
+	expected := map[string]Aggregation{
+		"by_brand": (&TermsAggregation{Field: "brand"}).AddNested(
+			"avg_price", &MetricAggregation{Type: "avg", Field: "price"},
+		),
+	}
+
+	// Act
+	result, err := ParseAggregationsFromQuery(parsedURL.Query())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("ParseAggregationsFromQuery returned an unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Resulting aggregation map does not match expected.\nGot: %#v\nWant: %#v", result, expected)
+	}
+}
+
+func TestParseAggregationsFromQuery_MultipleTopLevel(t *testing.T) {
+	// Arrange
+	rawURL := "http://example.com?agg[types][terms][field]=type&agg[sales_by_month][date_histogram][field]=date&agg[sales_by_month][date_histogram][interval]=1M"
+	parsedURL, _ := url.Parse(rawURL)
+
+	// Expected
+	expected := map[string]Aggregation{
+		"types": &TermsAggregation{
+			Field: "type",
+		},
+		"sales_by_month": &DateHistogramAggregation{
+			Field:    "date",
+			Interval: "1M",
+		},
+	}
+
+	// Act
+	result, err := ParseAggregationsFromQuery(parsedURL.Query())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("ParseAggregationsFromQuery returned an unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Resulting aggregation map does not match expected.\nGot: %#v\nWant: %#v", result, expected)
+	}
+}
+
+func TestParseAggregationsFromQuery_IgnoresNonAggParams(t *testing.T) {
+	// Arrange
+	rawURL := "http://example.com?query=search&from=10&agg[types][terms][field]=type"
+	parsedURL, _ := url.Parse(rawURL)
+
+	// Expected
+	expected := map[string]Aggregation{
+		"types": &TermsAggregation{Field: "type"},
+	}
+
+	// Act
+	result, err := ParseAggregationsFromQuery(parsedURL.Query())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("ParseAggregationsFromQuery returned an unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Resulting aggregation map does not match expected.\nGot: %#v\nWant: %#v", result, expected)
+	}
+}
+
+func TestParseAggregationsFromQuery_ErrorOnStructureConflict(t *testing.T) {
+	// Arrange
+	rawURL := "http://example.com?agg[types][terms]=some_value&agg[types][terms][field]=type"
+	parsedURL, _ := url.Parse(rawURL)
+
+	// Act
+	_, err := ParseAggregationsFromQuery(parsedURL.Query())
+
+	// Assert
+	if err == nil {
+		t.Fatal("Expected an error due to structure conflict, but got none")
+	}
+}
+
+func TestParseAggregationsFromQuery_URLEncoded(t *testing.T) {
+	// Arrange
+	rawURL := "http://localhost:8000/collection/region/_search?sort=created%3Aasc&from=0&size=20&agg[%E4%BE%9B%E5%BA%94%E5%95%86][terms][field]=provider&agg[%E4%BE%9B%E5%BA%94%E5%95%86][terms][size]=100"
+	parsedURL, _ := url.Parse(rawURL)
+
+	// Expected
+	expected := map[string]Aggregation{
+		"供应商": &TermsAggregation{
+			Field: "provider",
+			Size:  100,
+		},
+	}
+
+	// Act
+	result, err := ParseAggregationsFromQuery(parsedURL.Query())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("ParseAggregationsFromQuery returned an unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Resulting aggregation map does not match expected.\nGot: %#v\nWant: %#v", result, expected)
+	}
+}

--- a/core/orm/query.go
+++ b/core/orm/query.go
@@ -25,10 +25,11 @@ package orm
 
 import (
 	"fmt"
-	"infini.sh/framework/core/param"
 	"strconv"
 	"strings"
 	"unicode"
+
+	"infini.sh/framework/core/param"
 )
 
 type QueryType string
@@ -109,6 +110,7 @@ type QueryBuilder struct {
 	builtFuzziness bool
 
 	requestBodyBytes []byte
+	Aggs map[string]Aggregation
 }
 
 func NewQuery() *QueryBuilder {
@@ -119,6 +121,10 @@ func NewQuery() *QueryBuilder {
 
 func (q *QueryBuilder) SetRequestBodyBytes(bytes []byte) {
 	q.requestBodyBytes = bytes
+}
+// SetAggregations sets the aggregations for the query builder.
+func (q *QueryBuilder) SetAggregations(aggs map[string]Aggregation) {
+	q.Aggs = aggs
 }
 
 func (q *QueryBuilder) RequestBodyBytesVal() []byte {

--- a/core/orm/query_args_parser.go
+++ b/core/orm/query_args_parser.go
@@ -135,7 +135,14 @@ func NewQueryBuilderFromRequest(req *http.Request, defaultField ...string) (*Que
 			builder.Size(size)
 		}
 	}
-
+	// Handle aggregations
+	aggs, err := ParseAggregationsFromQuery(req.URL.Query())
+	if err != nil {
+		return nil, err
+	}
+	if len(aggs) > 0 {
+		builder.Aggs = aggs
+	}
 	return builder, nil
 }
 

--- a/modules/elastic/orm.go
+++ b/modules/elastic/orm.go
@@ -406,6 +406,17 @@ func (handler *ElasticORM) SearchV2(ctx *api.Context, qb *api.QueryBuilder) (*ap
 		} else {
 			dsl = orm.BuildQueryDSL(qb)
 		}
+		if len(qb.Aggs) > 0 {
+			aggBuilder := orm.AggreationBuilder{}
+			aggs, err := aggBuilder.Build(qb.Aggs)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build aggregations: %w", err)
+			}
+			if dsl == nil {
+				dsl = make(map[string]interface{})
+			}
+			dsl["aggs"] = aggs
+		}
 
 		if dsl != nil {
 			////parse query, remove unused parameters

--- a/modules/elastic/orm/aggs.go
+++ b/modules/elastic/orm/aggs.go
@@ -1,0 +1,150 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package orm
+
+import (
+	"fmt"
+
+	"infini.sh/framework/core/orm"
+)
+
+type ESAggregation struct {
+	Terms         *esTermsAggregation         `json:"terms,omitempty"`
+	DateHistogram *esDateHistogramAggregation `json:"date_histogram,omitempty"`
+	Avg           *esMetricAggregation        `json:"avg,omitempty"`
+	Sum           *esMetricAggregation        `json:"sum,omitempty"`
+	Min           *esMetricAggregation        `json:"min,omitempty"`
+	Max           *esMetricAggregation        `json:"max,omitempty"`
+	Cardinality   *esMetricAggregation        `json:"cardinality,omitempty"`
+	Stats         *esMetricAggregation        `json:"stats,omitempty"`
+	Percentiles   *esPercentilesAggregation   `json:"percentiles,omitempty"`
+	NestedAggs    map[string]*ESAggregation   `json:"aggs,omitempty"`
+}
+
+type esTermsAggregation struct {
+	Field string `json:"field,omitempty"`
+	Size  int    `json:"size,omitempty"`
+}
+
+type esMetricAggregation struct {
+	Field string `json:"field,omitempty"`
+}
+
+type esPercentilesAggregation struct {
+	Field    string    `json:"field,omitempty"`
+	Percents []float64 `json:"percents,omitempty"`
+}
+
+type esDateHistogramAggregation struct {
+	Field            string `json:"field,omitempty"`
+	CalendarInterval string `json:"calendar_interval,omitempty"` // Note the ES-specific field name
+	Format           string `json:"format,omitempty"`
+	TimeZone         string `json:"time_zone,omitempty"`
+}
+
+// AggreationBuilder is responsible for compiling an abstract aggreation Request into an ES query.
+type AggreationBuilder struct{}
+
+// New creates a new Elasticsearch aggreation builder.
+func New() *AggreationBuilder {
+	return &AggreationBuilder{}
+}
+
+// Build takes an abstract request and returns a JSON byte slice ready to be sent to Elasticsearch.
+func (c *AggreationBuilder) Build(aggs map[string]orm.Aggregation) (any, error) {
+	translatedAggs := make(map[string]*ESAggregation)
+
+	// If there are aggregations, translate them.
+	if len(aggs) > 0 {
+		for name, agg := range aggs {
+			esAgg, err := c.translateAggregation(agg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to translate aggregation '%s': %w", name, err)
+			}
+			translatedAggs[name] = esAgg
+		}
+	}
+
+	return translatedAggs, nil
+}
+
+// translateAggregation is a recursive function that converts an abstract Aggregation
+// into its specific esAggregation representation.
+func (c *AggreationBuilder) translateAggregation(agg orm.Aggregation) (*ESAggregation, error) {
+	esAgg := &ESAggregation{}
+
+	// Use a type switch to handle different kinds of abstract aggregations.
+	switch v := agg.(type) {
+	case *orm.TermsAggregation:
+		esAgg.Terms = &esTermsAggregation{
+			Field: v.Field,
+			Size:  v.Size,
+		}
+	case *orm.MetricAggregation:
+		metric := &esMetricAggregation{Field: v.Field}
+		switch v.Type {
+		case "avg":
+			esAgg.Avg = metric
+		case "sum":
+			esAgg.Sum = metric
+		case "min":
+			esAgg.Min = metric
+		case "max":
+			esAgg.Max = metric
+		case "cardinality":
+			esAgg.Cardinality = metric
+		default:
+			return nil, fmt.Errorf("unsupported metric aggregation type: %s", v.Type)
+		}
+	case *orm.PercentilesAggregation:
+		esAgg.Percentiles = &esPercentilesAggregation{
+			Field:    v.Field,
+			Percents: v.Percents,
+		}
+	case *orm.DateHistogramAggregation:
+		esAgg.DateHistogram = &esDateHistogramAggregation{
+			Field:            v.Field,
+			CalendarInterval: v.Interval,
+			Format:           v.Format,
+			TimeZone:         v.TimeZone,
+		}
+	default:
+		return nil, fmt.Errorf("unsupported aggregation type: %T", v)
+	}
+
+	// Recursively translate any nested aggregations.
+	nested := agg.GetNested()
+	if len(nested) > 0 {
+		esAgg.NestedAggs = make(map[string]*ESAggregation)
+		for name, subAgg := range nested {
+			translatedSub, err := c.translateAggregation(subAgg)
+			if err != nil {
+				return nil, err // Propagate error
+			}
+			esAgg.NestedAggs[name] = translatedSub
+		}
+	}
+
+	return esAgg, nil
+}

--- a/modules/elastic/orm/aggs_test.go
+++ b/modules/elastic/orm/aggs_test.go
@@ -1,0 +1,203 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package orm
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"infini.sh/framework/core/orm"
+	"infini.sh/framework/core/util"
+)
+
+// assertJSONEquals is a helper function to compare if two JSON sources are equivalent.
+// It unmarshals them into maps and uses reflect.DeepEqual for a robust comparison,
+// ignoring differences in whitespace and key order.
+func assertJSONEquals(t *testing.T, got []byte, expected string) {
+	t.Helper() // Marks this function as a test helper.
+
+	var gotMap, expectedMap map[string]interface{}
+
+	if err := json.Unmarshal(got, &gotMap); err != nil {
+		t.Fatalf("Failed to unmarshal 'got' JSON: %v\nJSON was: %s", err, string(got))
+	}
+	if err := json.Unmarshal([]byte(expected), &expectedMap); err != nil {
+		t.Fatalf("Failed to unmarshal 'expected' JSON: %v\nJSON was: %s", err, expected)
+	}
+
+	if !reflect.DeepEqual(gotMap, expectedMap) {
+		gotPretty, _ := json.MarshalIndent(gotMap, "", "  ")
+		expectedPretty, _ := json.MarshalIndent(expectedMap, "", "  ")
+		t.Errorf("JSON mismatch:\n--- GOT ---\n%s\n\n--- EXPECTED ---\n%s", string(gotPretty), string(expectedPretty))
+	}
+}
+
+// TestBuild_SingleTermsAggregation tests the compilation of a simple, single-level terms aggregation.
+func TestBuild_SingleTermsAggregation(t *testing.T) {
+	// Arrange: Build an abstract request.
+	request := map[string]orm.Aggregation{
+			"group_by_brand": &orm.TermsAggregation{
+				Field: "brand.keyword",
+				Size:  10,
+			},
+		}
+
+	builder := New()
+	resultJSON, err := builder.Build(request)
+
+	// Assert: Check for errors and compare the output JSON.
+	if err != nil {
+		t.Fatalf("Build() returned an unexpected error: %v", err)
+	}
+
+	expectedJSON := `{
+			"group_by_brand": {
+				"terms": {
+					"field": "brand.keyword",
+					"size": 10
+				}
+			}
+	}`
+
+	assertJSONEquals(t, util.MustToJSONBytes(resultJSON), expectedJSON)
+}
+
+// TestBuild_NestedAggregation tests a terms aggregation with a nested metric aggregation.
+func TestBuild_NestedAggregation(t *testing.T) {
+	// Arrange
+	request := map[string]orm.Aggregation{
+			"products_by_type": (&orm.TermsAggregation{
+				Field: "type.keyword",
+			}).AddNested("average_price", &orm.MetricAggregation{
+				Field: "price",
+				Type: "avg",
+			}),
+		}
+
+	// Act
+	builder := New()
+	resultJSON, err := builder.Build(request)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Build() returned an unexpected error: %v", err)
+	}
+
+	expectedJSON := `{
+			"products_by_type": {
+				"terms": {
+					"field": "type.keyword"
+				},
+				"aggs": {
+					"average_price": {
+						"avg": {
+							"field": "price"
+						}
+					}
+				}
+			}
+	}`
+
+	assertJSONEquals(t, util.MustToJSONBytes(resultJSON), expectedJSON)
+}
+
+// TestBuild_MultipleTopLevelAggs tests a request with multiple aggregations at the root level.
+func TestBuild_MultipleTopLevelAggs(t *testing.T) {
+	// Arrange
+	request := map[string]orm.Aggregation{
+		"total_sales": &orm.MetricAggregation{
+			Type: "avg",
+			Field: "price",
+		},
+		"sales_by_month": &orm.DateHistogramAggregation{
+			Field:    "order_date",
+			Interval: "1M",
+			TimeZone: "UTC",
+		},
+	}
+
+	builder := New()
+	resultJSON, err := builder.Build(request)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Compile() returned an unexpected error: %v", err)
+	}
+
+	expectedJSON := `{
+			"total_sales": {
+				"avg": {
+					"field": "price"
+				}
+			},
+			"sales_by_month": {
+				"date_histogram": {
+					"field": "order_date",
+					"calendar_interval": "1M",
+					"time_zone": "UTC"
+				}
+			}
+	}`
+
+	assertJSONEquals(t, util.MustToJSONBytes(resultJSON), expectedJSON)
+}
+
+// TestBuild_NoAggregations tests that a request with no aggregations compiles correctly.
+func TestBuild_NoAggregations(t *testing.T) {
+	// Arrange
+	var request = map[string]orm.Aggregation{}
+
+	builder := New()
+	resultJSON, err := builder.Build(request)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Build() returned an unexpected error: %v", err)
+	}
+
+	// The 'aggs' key should be omitted from the final JSON.
+	expectedJSON := `{
+	}`
+
+	assertJSONEquals(t, util.MustToJSONBytes(resultJSON), expectedJSON)
+}
+
+// unsupportedAgg is a mock struct for testing error handling.
+type unsupportedAgg struct{ orm.TermsAggregation }
+
+// TestBuild_UnsupportedAggregationType tests that the compiler returns an error for unknown types.
+func TestBuild_UnsupportedAggregationType(t *testing.T) {
+	request :=  map[string]orm.Aggregation{
+			"bad_agg": &unsupportedAgg{},
+		}
+
+	builder := New()
+	_, err := builder.Build(request)
+
+	// Assert
+	if err == nil {
+		t.Fatal("Build() was expected to return an error, but it did not")
+	}
+}


### PR DESCRIPTION
## What does this PR do
This pull request introduces a comprehensive system for parsing, representing, and building query aggregations in the ORM and Elasticsearch integration. The changes allow the API to accept aggregation parameters in URL queries, parse them into abstract aggregation objects, and translate them into Elasticsearch-compatible DSL. The update includes new core abstractions, parsing logic, integration into the query builder, and an Elasticsearch-specific builder, along with thorough test coverage.

**Aggregation Abstractions and Parsing (Core ORM):**
- Introduced new aggregation interfaces and concrete types (`Aggregation`, `TermsAggregation`, `MetricAggregation`, etc.) in `core/orm/aggs.go` to represent different aggregation operations and support nested aggregations.
- Added a robust parser (`ParseAggregationsFromQuery`) in `core/orm/aggs_args_parser.go` to convert URL query parameters into nested aggregation objects, including support for decoding numbers and handling nested structures.
- Provided comprehensive tests for the parser covering single, nested, multiple, and error cases in `core/orm/aggs_args_parser_test.go`.

**Query Builder Integration:**
- Extended the `QueryBuilder` struct in `core/orm/query.go` to include an `Aggs` field for storing parsed aggregations and added a setter method. [[1]](diffhunk://#diff-ebb7889b112ada31833848599efde6aa9529009602a63633bf6fae0e555a49b8R113) [[2]](diffhunk://#diff-ebb7889b112ada31833848599efde6aa9529009602a63633bf6fae0e555a49b8R125-R128)
- Updated the query argument parser in `core/orm/query_args_parser.go` to parse and attach aggregations from incoming HTTP requests.

**Elasticsearch Aggregation Builder:**
- Added `modules/elastic/orm/aggs.go` with an `AggreationBuilder` that translates abstract aggregation objects into Elasticsearch DSL, supporting all major aggregation types and nested aggregations.
- Integrated the aggregation builder into the search flow in `modules/elastic/orm.go`, ensuring that parsed aggregations are included in the final query if present.

These changes together enable flexible, type-safe, and extensible aggregation handling from API request to Elasticsearch query.

---

**Core ORM: Aggregation Abstractions and Parsing**
- Added new aggregation interfaces and types to `core/orm/aggs.go` for representing terms, metrics, date histograms, percentiles, and nested aggregations.
- Implemented a robust parser in `core/orm/aggs_args_parser.go` to convert URL query parameters into nested aggregation objects, with custom decode hooks and error handling.
- Added comprehensive unit tests for aggregation parsing in `core/orm/aggs_args_parser_test.go`.

**Query Builder Integration**
- Extended `QueryBuilder` in `core/orm/query.go` to support storing and setting aggregations, and updated request argument parsing to include aggregation support. [[1]](diffhunk://#diff-ebb7889b112ada31833848599efde6aa9529009602a63633bf6fae0e555a49b8R113) [[2]](diffhunk://#diff-ebb7889b112ada31833848599efde6aa9529009602a63633bf6fae0e555a49b8R125-R128) [[3]](diffhunk://#diff-0010584bd1716f3a446299396bd06b0d50689c11e4e67b7a76584b9e89ad8539L138-R145)

**Elasticsearch Integration**
- Added `AggreationBuilder` in `modules/elastic/orm/aggs.go` to translate abstract aggregation objects into Elasticsearch DSL, supporting all major types and nested aggregations.
- Integrated aggregation building into the search flow in `modules/elastic/orm.go`, adding aggregations to the final query if present.
## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation