### PR TITLE
feat: add support for query_string query

### DIFF
--- a/core/elastic/search.go
+++ b/core/elastic/search.go
@@ -158,9 +158,8 @@ func GetDateHistogramIntervalField(distribution, version string, bucketSize stri
 	return Interval, nil
 }
 
-
 const (
 	Interval         string = "interval"
-	CalendarInterval  = "calendar_interval"
-	FixedInterval     = "fixed_interval"
+	CalendarInterval        = "calendar_interval"
+	FixedInterval           = "fixed_interval"
 )

--- a/core/elastic/search.go
+++ b/core/elastic/search.go
@@ -24,8 +24,9 @@
 package elastic
 
 import (
-	"infini.sh/framework/core/util"
 	"time"
+
+	"infini.sh/framework/core/util"
 )
 
 type SearchTemplate struct {
@@ -142,7 +143,7 @@ func BuildSearchTermFilter(filterParam SearchFilterParam) []util.MapStr {
 
 func GetDateHistogramIntervalField(distribution, version string, bucketSize string) (string, error) {
 	if distribution == Easysearch || distribution == Opensearch {
-		return "interval", nil
+		return Interval, nil
 	}
 	cr, err := util.VersionCompare(version, "8.0")
 	if err != nil {
@@ -150,9 +151,16 @@ func GetDateHistogramIntervalField(distribution, version string, bucketSize stri
 	}
 	if cr > -1 {
 		if util.StringInArray([]string{"1w", "week", "1M", "month", "1q", "quarter", "1y", "year"}, bucketSize) {
-			return "calendar_interval", nil
+			return CalendarInterval, nil
 		}
-		return "fixed_interval", nil
+		return FixedInterval, nil
 	}
-	return "interval", nil
+	return Interval, nil
 }
+
+
+const (
+	Interval         string = "interval"
+	CalendarInterval  = "calendar_interval"
+	FixedInterval     = "fixed_interval"
+)

--- a/core/orm/aggs.go
+++ b/core/orm/aggs.go
@@ -206,6 +206,7 @@ func (a *FilterAggregation) AddNested(name string, sub Aggregation) Aggregation 
 type DateRangeAggregation struct {
 	baseAggregation
 	Field string `json:"field"`
+	TimeZone string `json:"time_zone,omitempty"`
 	Format string `json:"format,omitempty"`
 	Ranges []interface{} `json:"ranges"`
 }

--- a/core/orm/aggs.go
+++ b/core/orm/aggs.go
@@ -38,23 +38,23 @@ type Aggregation interface {
 
 const (
 	// Metric types
-	MetricAvg        = "avg"
-	MetricSum        = "sum"
-	MetricMin        = "min"
-	MetricMax        = "max"
-	MetricCount      = "count"
+	MetricAvg         = "avg"
+	MetricSum         = "sum"
+	MetricMin         = "min"
+	MetricMax         = "max"
+	MetricCount       = "count"
 	MetricPercentiles = "percentiles"
-	MetricTopHits    = "top_hits"
+	MetricTopHits     = "top_hits"
 	MetricCardinality = "cardinality"
-	MetricMedian = "median_absolute_deviation"
+	MetricMedian      = "median_absolute_deviation"
 	// Bucket types
 	MetricBucketTerms         = "terms"
 	MetricBucketDateHistogram = "date_histogram"
-	MetricBucketFilter      = "filter"
-	MetricDateRange = "date_range"
+	MetricBucketFilter        = "filter"
+	MetricDateRange           = "date_range"
 	// Pipeline types
 	MetricPipelineDerivative = "derivative"
-	MetricSumBucket = "sum_bucket"
+	MetricSumBucket          = "sum_bucket"
 )
 
 // baseAggregation provides common functionality for all aggregation types,
@@ -63,7 +63,7 @@ type baseAggregation struct {
 	// NestedAggs holds any sub-aggregations.
 	NestedAggs map[string]Aggregation `json:"-"`
 	// Params can hold additional parameters specific to certain aggregation types.
-	Params 	 map[string]interface{} `json:"-"`
+	Params map[string]interface{} `json:"-"`
 }
 
 // AddNested adds a sub-aggregation to the base aggregation.
@@ -107,9 +107,9 @@ func (a *TermsAggregation) AddNested(name string, sub Aggregation) Aggregation {
 
 // MetricAggregation represents a single-value metric calculation (avg, sum, etc.).
 type MetricAggregation struct {
-	baseAggregation // Although metrics rarely have sub-aggs in ES, the model allows it.
-	Type  string `mapstructure:"-"` // Type of metric: "avg", "sum", etc. Not part of the decoded structure.
-	Field string
+	baseAggregation        // Although metrics rarely have sub-aggs in ES, the model allows it.
+	Type            string `mapstructure:"-"` // Type of metric: "avg", "sum", etc. Not part of the decoded structure.
+	Field           string
 }
 
 // NewMetricAggregation creates a new MetricAggregation of the specified type and field.
@@ -132,10 +132,11 @@ type PipelineAggregation struct {
 	Type        string `mapstructure:"-"` // Type of pipeline: "derivative", "sum_bucket", etc. Not part of the decoded structure.
 	BucketsPath string
 }
+
 // NewPipelineAggregation creates a new PipelineAggregation of the specified type and buckets path.
-func NewPipelineAggregation(pipelineType, bucketsPath string)  *PipelineAggregation {
+func NewPipelineAggregation(pipelineType, bucketsPath string) *PipelineAggregation {
 	switch pipelineType {
-	case  MetricSumBucket:
+	case MetricSumBucket:
 		// Valid pipeline types
 	default:
 		panic("invalid pipeline type: " + pipelineType)
@@ -155,10 +156,10 @@ func (a *MetricAggregation) AddNested(name string, sub Aggregation) Aggregation 
 // DateHistogramAggregation represents bucketing documents by a date/time interval.
 type DateHistogramAggregation struct {
 	baseAggregation
-	Field    string
-	Interval string // A generic interval string like "1d", "1M", "1h".
-	Format   string
-	TimeZone string
+	Field         string
+	Interval      string // A generic interval string like "1d", "1M", "1h".
+	Format        string
+	TimeZone      string
 	IntervalField string // es-specific field name for backward compatibility
 }
 
@@ -197,6 +198,7 @@ type FilterAggregation struct {
 	// Query holds the filter criteria for this aggregation.
 	Query map[string]interface{} `json:"query"`
 }
+
 // AddNested provides a correctly typed chained call for FilterAggregation.
 func (a *FilterAggregation) AddNested(name string, sub Aggregation) Aggregation {
 	a.baseAggregation.AddNested(name, sub)
@@ -205,11 +207,12 @@ func (a *FilterAggregation) AddNested(name string, sub Aggregation) Aggregation 
 
 type DateRangeAggregation struct {
 	baseAggregation
-	Field string `json:"field"`
-	TimeZone string `json:"time_zone,omitempty"`
-	Format string `json:"format,omitempty"`
-	Ranges []interface{} `json:"ranges"`
+	Field    string        `json:"field"`
+	TimeZone string        `json:"time_zone,omitempty"`
+	Format   string        `json:"format,omitempty"`
+	Ranges   []interface{} `json:"ranges"`
 }
+
 // AddNested provides a correctly typed chained call for DateRangeAggregation.
 func (a *DateRangeAggregation) AddNested(name string, sub Aggregation) Aggregation {
 	a.baseAggregation.AddNested(name, sub)

--- a/core/orm/aggs.go
+++ b/core/orm/aggs.go
@@ -51,6 +51,7 @@ const (
 	MetricBucketTerms         = "terms"
 	MetricBucketDateHistogram = "date_histogram"
 	MetricBucketFilter      = "filter"
+	MetricDateRange = "date_range"
 	// Pipeline types
 	MetricPipelineDerivative = "derivative"
 	MetricSumBucket = "sum_bucket"
@@ -198,6 +199,18 @@ type FilterAggregation struct {
 }
 // AddNested provides a correctly typed chained call for FilterAggregation.
 func (a *FilterAggregation) AddNested(name string, sub Aggregation) Aggregation {
+	a.baseAggregation.AddNested(name, sub)
+	return a
+}
+
+type DateRangeAggregation struct {
+	baseAggregation
+	Field string `json:"field"`
+	Format string `json:"format,omitempty"`
+	Ranges []interface{} `json:"ranges"`
+}
+// AddNested provides a correctly typed chained call for DateRangeAggregation.
+func (a *DateRangeAggregation) AddNested(name string, sub Aggregation) Aggregation {
 	a.baseAggregation.AddNested(name, sub)
 	return a
 }

--- a/core/orm/aggs.go
+++ b/core/orm/aggs.go
@@ -53,6 +53,7 @@ const (
 	MetricBucketFilter      = "filter"
 	// Pipeline types
 	MetricPipelineDerivative = "derivative"
+	MetricSumBucket = "sum_bucket"
 )
 
 // baseAggregation provides common functionality for all aggregation types,
@@ -124,6 +125,26 @@ func NewMetricAggregation(metricType, field string) *MetricAggregation {
 	}
 }
 
+// PipelineAggregation represents a pipeline aggregation that processes the output of other aggregations.
+type PipelineAggregation struct {
+	baseAggregation
+	Type        string `mapstructure:"-"` // Type of pipeline: "derivative", "sum_bucket", etc. Not part of the decoded structure.
+	BucketsPath string
+}
+// NewPipelineAggregation creates a new PipelineAggregation of the specified type and buckets path.
+func NewPipelineAggregation(pipelineType, bucketsPath string)  *PipelineAggregation {
+	switch pipelineType {
+	case  MetricSumBucket:
+		// Valid pipeline types
+	default:
+		panic("invalid pipeline type: " + pipelineType)
+	}
+	return &PipelineAggregation{
+		Type:        pipelineType,
+		BucketsPath: bucketsPath,
+	}
+}
+
 // AddNested provides a correctly typed chained call for MetricAggregation.
 func (a *MetricAggregation) AddNested(name string, sub Aggregation) Aggregation {
 	a.baseAggregation.AddNested(name, sub)
@@ -137,6 +158,7 @@ type DateHistogramAggregation struct {
 	Interval string // A generic interval string like "1d", "1M", "1h".
 	Format   string
 	TimeZone string
+	IntervalField string // es-specific field name for backward compatibility
 }
 
 // AddNested provides a correctly typed chained call for DateHistogramAggregation.

--- a/core/orm/aggs_args_parser.go
+++ b/core/orm/aggs_args_parser.go
@@ -14,7 +14,6 @@ import (
 // keyPartRegex is used to parse keys like "agg[key1][key2]" into parts: "agg", "key1", "key2".
 var keyPartRegex = regexp.MustCompile(`^([^\[\]]+)|\[([^\[\]]*)\]`)
 
-
 // ParseAggregationsFromQuery takes URL query values and converts them into a map of abstract aggregations.
 func ParseAggregationsFromQuery(values url.Values) (map[string]Aggregation, error) {
 	// Step 1: Convert flat URL params into a nested map.
@@ -47,7 +46,7 @@ func parseToNestedMap(values url.Values) (map[string]interface{}, error) {
 			} else {
 				part = match[2]
 			}
-			
+
 			decodedPart, err := url.QueryUnescape(part)
 			if err != nil {
 				// Fallback to the raw part if decoding fails
@@ -55,7 +54,7 @@ func parseToNestedMap(values url.Values) (map[string]interface{}, error) {
 			}
 			parts = append(parts, decodedPart)
 		}
-		
+
 		if len(parts) == 0 || parts[0] != "agg" {
 			continue // Malformed key, skip.
 		}
@@ -115,7 +114,7 @@ func stringToNumberHook() mapstructure.DecodeHookFunc {
 		if !isNumeric {
 			return data, nil
 		}
-		
+
 		str := data.(string)
 
 		// Try to parse as integer first.

--- a/core/orm/aggs_args_parser_test.go
+++ b/core/orm/aggs_args_parser_test.go
@@ -10,7 +10,7 @@ func TestParseAggregationsFromQuery_SingleTerms(t *testing.T) {
 	// Arrange
 	rawURL := "http://example.com?agg[types][terms][field]=product.keyword&agg[types][terms][size]=5"
 	parsedURL, _ := url.Parse(rawURL)
-	
+
 	// Expected abstract structure
 	expected := map[string]Aggregation{
 		"types": &TermsAggregation{

--- a/core/orm/aggs_test.go
+++ b/core/orm/aggs_test.go
@@ -33,7 +33,7 @@ func TestTermsAggregation(t *testing.T) {
 	// Create a terms aggregation
 	termsAgg := TermsAggregation{
 		Field: "field1",
-		Size: 10,
+		Size:  10,
 	}
 	termsAgg.AddNested("count_values", NewMetricAggregation(MetricCount, "field2")).AddNested("max_value", NewMetricAggregation(MetricMax, "field2"))
 	assert.Equal(t, 2, len(termsAgg.GetNested()), "Expected one nested aggregation")
@@ -55,13 +55,13 @@ func TestDateHistogramAggregation(t *testing.T) {
 func TestAggregationWithParams(t *testing.T) {
 	termsAgg := TermsAggregation{
 		Field: "field1",
-		Size: 10,
+		Size:  10,
 	}
 	params := map[string]interface{}{
-			"order": map[string]string{
-				"_count": "desc",
-			},
-		}
+		"order": map[string]string{
+			"_count": "desc",
+		},
+	}
 	termsAgg.SetParams(params)
 	assert.Equal(t, "desc", termsAgg.Params["order"].(map[string]string)["_count"], "Expected order param to be set")
 }

--- a/core/orm/query.go
+++ b/core/orm/query.go
@@ -51,6 +51,7 @@ const (
 	QueryIn          QueryType = "in"
 	QueryNotIn       QueryType = "not_in"
 	QueryMatchPhrase QueryType = "match_phrase"
+	QueryQueryString QueryType = "query_string"
 )
 
 type Clause struct {
@@ -310,6 +311,7 @@ func RegexpQuery(field string, value interface{}) *Clause {
 
 const fuzzyFuzziness = "fuzziness"
 const phraseSlop = "slop"
+const queryStringDefaultOperator = "default_operator"
 
 func FuzzyQuery(field string, value interface{}, fuzziness int) *Clause {
 	param := param.Parameters{}
@@ -333,6 +335,12 @@ func MatchPhraseQuery(field, value string, slop int) *Clause {
 	param := param.Parameters{}
 	param.Set(phraseSlop, slop)
 	return newLeaf(field, QueryMatchPhrase, value, &param)
+}
+
+func QueryStringQuery(field string, value string, defaultOperator string) *Clause {
+	param := param.Parameters{}
+	param.Set(queryStringDefaultOperator, defaultOperator)
+	return newLeaf(field, QueryQueryString, value, &param)
 }
 
 type RangeQueryBuilder struct {

--- a/core/orm/query.go
+++ b/core/orm/query.go
@@ -114,7 +114,7 @@ type QueryBuilder struct {
 	filters []*Clause
 
 	requestBodyBytes []byte
-	Aggs map[string]Aggregation
+	Aggs             map[string]Aggregation
 }
 
 func NewQuery() *QueryBuilder {
@@ -126,6 +126,7 @@ func NewQuery() *QueryBuilder {
 func (q *QueryBuilder) SetRequestBodyBytes(bytes []byte) {
 	q.requestBodyBytes = bytes
 }
+
 // SetAggregations sets the aggregations for the query builder.
 func (q *QueryBuilder) SetAggregations(aggs map[string]Aggregation) {
 	q.Aggs = aggs
@@ -339,7 +340,9 @@ func MatchPhraseQuery(field, value string, slop int) *Clause {
 
 func QueryStringQuery(field string, value string, defaultOperator string) *Clause {
 	param := param.Parameters{}
-	param.Set(queryStringDefaultOperator, defaultOperator)
+	if defaultOperator != "" {
+		param.Set(queryStringDefaultOperator, defaultOperator)
+	}
 	return newLeaf(field, QueryQueryString, value, &param)
 }
 

--- a/core/orm/query_test.go
+++ b/core/orm/query_test.go
@@ -25,10 +25,11 @@ package orm
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"infini.sh/framework/core/util"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"infini.sh/framework/core/util"
 )
 
 func TestTermQuery(t *testing.T) {
@@ -188,6 +189,16 @@ func TestRangeGtQuery(t *testing.T) {
 func TestRangeLtQuery(t *testing.T) {
 	q := Range("score").Lt(10)
 	assertLeaf(t, q, "score", QueryRangeLt, 10)
+}
+
+func TestQueryStringQuery(t *testing.T) {
+	var (
+		field = "name,description"
+		value = "foo bar"
+		defaultOperator = "OR"
+	)
+	q := QueryStringQuery(field, value, defaultOperator)
+	assertLeaf(t, q, field, QueryQueryString, value)
 }
 
 // Helper: check leaf structure

--- a/core/orm/query_test.go
+++ b/core/orm/query_test.go
@@ -193,8 +193,8 @@ func TestRangeLtQuery(t *testing.T) {
 
 func TestQueryStringQuery(t *testing.T) {
 	var (
-		field = "name,description"
-		value = "foo bar"
+		field           = "name,description"
+		value           = "foo bar"
 		defaultOperator = "OR"
 	)
 	q := QueryStringQuery(field, value, defaultOperator)

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -13,7 +13,7 @@ Information about release notes of INFINI Framework is provided here.
 ### 🚀 Features  
 - feat: add delete by query v2 #194
 - feat: support aggregation queries in orm
-
+- feat: add support for `query_string` query
 ### 🐛 Bug fix  
 - fix: localhost/127.0.0.1 with noproxy #185
 - fix: cluster metadata lost #200

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -237,8 +237,8 @@ func Test_Cache_ReplaceChangesSize(t *testing.T) {
 }
 
 func Test_Cache_ResizeOnTheFly(t *testing.T) {
-	// On a busy system or during a slow run, the cleanup might take longer. 
-	// When this happens, the test continues 
+	// On a busy system or during a slow run, the cleanup might take longer.
+	// When this happens, the test continues
 	// and runs its assertions (e.g., assert.Equal(t, cache.GetDropped(), 2))
 	// before the cache has actually been pruned, causing the test to fail.
 	if os.Getenv("CI") == "true" {

--- a/lib/cache/layeredcache_test.go
+++ b/lib/cache/layeredcache_test.go
@@ -225,8 +225,8 @@ func Test_LayeredCache_RemovesOldestItemWhenFull(t *testing.T) {
 }
 
 func Test_LayeredCache_ResizeOnTheFly(t *testing.T) {
-	// On a busy system or during a slow run, the cleanup might take longer. 
-	// When this happens, the test continues 
+	// On a busy system or during a slow run, the cleanup might take longer.
+	// When this happens, the test continues
 	// and runs its assertions (e.g., assert.Equal(t, cache.GetDropped(), 2))
 	// before the cache has actually been pruned, causing the test to fail.
 	if os.Getenv("CI") == "true" {

--- a/modules/elastic/orm/aggs.go
+++ b/modules/elastic/orm/aggs.go
@@ -40,13 +40,13 @@ type ESAggregation struct {
 	Cardinality   *esMetricAggregation        `json:"cardinality,omitempty"`
 	Percentiles   *esPercentilesAggregation   `json:"percentiles,omitempty"`
 	NestedAggs    map[string]*ESAggregation   `json:"aggs,omitempty"`
-	Count   *esMetricAggregation        `json:"value_count,omitempty"`
-	Median *esMetricAggregation `json:"median_absolute_deviation,omitempty"`
-	Derivative 	*esPipelineAggregation    `json:"derivative,omitempty"`
-	Filter *esFilterAggregation `json:"filter,omitempty"`
-	TopHits map[string]interface{} `json:"top_hits,omitempty"`
-	SumBucket *esPipelineAggregation `json:"sum_bucket,omitempty"`
-	DateRange *esDateRangeAggregation `json:"date_range,omitempty"`
+	Count         *esMetricAggregation        `json:"value_count,omitempty"`
+	Median        *esMetricAggregation        `json:"median_absolute_deviation,omitempty"`
+	Derivative    *esPipelineAggregation      `json:"derivative,omitempty"`
+	Filter        *esFilterAggregation        `json:"filter,omitempty"`
+	TopHits       map[string]interface{}      `json:"top_hits,omitempty"`
+	SumBucket     *esPipelineAggregation      `json:"sum_bucket,omitempty"`
+	DateRange     *esDateRangeAggregation     `json:"date_range,omitempty"`
 }
 
 type esTermsAggregation struct {
@@ -66,8 +66,8 @@ type esPercentilesAggregation struct {
 type esDateHistogramAggregation struct {
 	Field            string `json:"field,omitempty"`
 	CalendarInterval string `json:"calendar_interval,omitempty"` // Note the ES-specific field name
-	FixedInterval    string `json:"fixed_interval,omitempty"` // Note the ES-specific field name
-	Interval string `json:"interval,omitempty"` // Deprecated but still supported by ES
+	FixedInterval    string `json:"fixed_interval,omitempty"`    // Note the ES-specific field name
+	Interval         string `json:"interval,omitempty"`          // Deprecated but still supported by ES
 	Format           string `json:"format,omitempty"`
 	TimeZone         string `json:"time_zone,omitempty"`
 }
@@ -77,9 +77,9 @@ type esPipelineAggregation struct {
 }
 type esFilterAggregation map[string]interface{}
 type esDateRangeAggregation struct {
-	Field  string        `json:"field,omitempty"`
-	Format string        `json:"format,omitempty"`
-	Ranges []interface{} `json:"ranges,omitempty"`
+	Field    string        `json:"field,omitempty"`
+	Format   string        `json:"format,omitempty"`
+	Ranges   []interface{} `json:"ranges,omitempty"`
 	TimeZone string        `json:"time_zone,omitempty"`
 }
 
@@ -149,11 +149,11 @@ func (c *AggreationBuilder) translateAggregation(agg orm.Aggregation) (*ESAggreg
 			Percents: v.Percents,
 		}
 	case *orm.DateHistogramAggregation:
-	
+
 		esAgg.DateHistogram = &esDateHistogramAggregation{
-			Field:            v.Field,
-			Format:           v.Format,
-			TimeZone:         v.TimeZone,
+			Field:    v.Field,
+			Format:   v.Format,
+			TimeZone: v.TimeZone,
 		}
 		switch v.IntervalField {
 		case elastic.CalendarInterval:
@@ -175,9 +175,9 @@ func (c *AggreationBuilder) translateAggregation(agg orm.Aggregation) (*ESAggreg
 		}
 	case *orm.DateRangeAggregation:
 		esAgg.DateRange = &esDateRangeAggregation{
-			Field:  v.Field,
-			Format: v.Format,
-			Ranges: v.Ranges,
+			Field:    v.Field,
+			Format:   v.Format,
+			Ranges:   v.Ranges,
 			TimeZone: v.TimeZone,
 		}
 	default:

--- a/modules/elastic/orm/aggs.go
+++ b/modules/elastic/orm/aggs.go
@@ -80,6 +80,7 @@ type esDateRangeAggregation struct {
 	Field  string        `json:"field,omitempty"`
 	Format string        `json:"format,omitempty"`
 	Ranges []interface{} `json:"ranges,omitempty"`
+	TimeZone string        `json:"time_zone,omitempty"`
 }
 
 // AggreationBuilder is responsible for compiling an abstract aggreation Request into an ES query.
@@ -177,6 +178,7 @@ func (c *AggreationBuilder) translateAggregation(agg orm.Aggregation) (*ESAggreg
 			Field:  v.Field,
 			Format: v.Format,
 			Ranges: v.Ranges,
+			TimeZone: v.TimeZone,
 		}
 	default:
 		return nil, fmt.Errorf("unsupported aggregation type: %T", v)

--- a/modules/elastic/orm/aggs.go
+++ b/modules/elastic/orm/aggs.go
@@ -46,6 +46,7 @@ type ESAggregation struct {
 	Filter *esFilterAggregation `json:"filter,omitempty"`
 	TopHits map[string]interface{} `json:"top_hits,omitempty"`
 	SumBucket *esPipelineAggregation `json:"sum_bucket,omitempty"`
+	DateRange *esDateRangeAggregation `json:"date_range,omitempty"`
 }
 
 type esTermsAggregation struct {
@@ -75,6 +76,11 @@ type esPipelineAggregation struct {
 	BucketsPath string `json:"buckets_path,omitempty"`
 }
 type esFilterAggregation map[string]interface{}
+type esDateRangeAggregation struct {
+	Field  string        `json:"field,omitempty"`
+	Format string        `json:"format,omitempty"`
+	Ranges []interface{} `json:"ranges,omitempty"`
+}
 
 // AggreationBuilder is responsible for compiling an abstract aggreation Request into an ES query.
 type AggreationBuilder struct{}
@@ -165,6 +171,12 @@ func (c *AggreationBuilder) translateAggregation(agg orm.Aggregation) (*ESAggreg
 	case *orm.PipelineAggregation:
 		esAgg.SumBucket = &esPipelineAggregation{
 			BucketsPath: v.BucketsPath,
+		}
+	case *orm.DateRangeAggregation:
+		esAgg.DateRange = &esDateRangeAggregation{
+			Field:  v.Field,
+			Format: v.Format,
+			Ranges: v.Ranges,
 		}
 	default:
 		return nil, fmt.Errorf("unsupported aggregation type: %T", v)

--- a/modules/elastic/orm/aggs_test.go
+++ b/modules/elastic/orm/aggs_test.go
@@ -28,6 +28,7 @@ import (
 	"reflect"
 	"testing"
 
+	"infini.sh/framework/core/elastic"
 	"infini.sh/framework/core/orm"
 	"infini.sh/framework/core/util"
 )
@@ -235,6 +236,7 @@ func TestBuild_ComplexAggregation(t *testing.T) {
 			request: map[string]orm.Aggregation{
 				"sales_over_time": (&orm.DateHistogramAggregation{
 					Field:    "sale_date",
+					IntervalField: elastic.CalendarInterval,
 					Interval: "1M",
 					TimeZone: "UTC",
 				}).AddNested("sales_by_region", (&orm.TermsAggregation{
@@ -271,6 +273,7 @@ func TestBuild_ComplexAggregation(t *testing.T) {
 				"request_over_time": (&orm.DateHistogramAggregation{
 					Field:    "timestamp",
 					Interval: "1M",
+					IntervalField: elastic.CalendarInterval,
 				}).AddNested("response_percentiles", &orm.PercentilesAggregation{
 					Field:    "response_time",
 					Percents: []float64{50, 90, 95},
@@ -298,6 +301,7 @@ func TestBuild_ComplexAggregation(t *testing.T) {
 			request: map[string]orm.Aggregation{
 				"sales_over_time": (&orm.DateHistogramAggregation{
 					Field:    "sale_date",
+					IntervalField: elastic.CalendarInterval,
 					Interval: "1M",
 				}).AddNested("avg_sale", orm.NewMetricAggregation(orm.MetricAvg, "sale_amount")).AddNested("sales_derivative", &orm.DerivativeAggregation{
 					BucketsPath: "avg_sale",

--- a/modules/elastic/orm/aggs_test.go
+++ b/modules/elastic/orm/aggs_test.go
@@ -438,6 +438,7 @@ func TestParseDateRangeAggregation(t *testing.T) {
 	dateRangeAgg := &orm.DateRangeAggregation{
 		Field:  "timestamp",
 		Format: "yyyy-MM-dd",
+		TimeZone: "UTC",
 		Ranges: []interface{}{
 			map[string]interface{}{"to": "2006-01-01"},
 			map[string]interface{}{"from": "2006-01-01", "to": "2010-02-01"},
@@ -456,6 +457,7 @@ func TestParseDateRangeAggregation(t *testing.T) {
 			"date_range": {
 				"field": "timestamp",
 				"format": "yyyy-MM-dd",
+				"time_zone": "UTC",
 				"ranges": [
 					{"to": "2006-01-01"},
 					{"from": "2006-01-01", "to": "2010-02-01"},

--- a/modules/elastic/orm/aggs_test.go
+++ b/modules/elastic/orm/aggs_test.go
@@ -129,6 +129,7 @@ func TestBuild_MultipleTopLevelAggs(t *testing.T) {
 		"sales_by_month": &orm.DateHistogramAggregation{
 			Field:    "order_date",
 			Interval: "1M",
+			IntervalField: elastic.CalendarInterval,
 			TimeZone: "UTC",
 		},
 	}
@@ -350,6 +351,7 @@ func TestBuildAggsWith(t *testing.T) {
   aggs := map[string]orm.Aggregation{
     "sales_over_time": (&orm.DateHistogramAggregation{
       Field:    "sale_date",
+			IntervalField: elastic.CalendarInterval,
       Interval: "1M",
     }).AddNested("sales_by_region", (&orm.TermsAggregation{
       Field: "region.keyword",

--- a/modules/elastic/orm/aggs_test.go
+++ b/modules/elastic/orm/aggs_test.go
@@ -59,11 +59,11 @@ func assertJSONEquals(t *testing.T, got []byte, expected string) {
 func TestBuild_SingleTermsAggregation(t *testing.T) {
 	// Arrange: Build an abstract request.
 	request := map[string]orm.Aggregation{
-			"group_by_brand": &orm.TermsAggregation{
-				Field: "brand.keyword",
-				Size:  10,
-			},
-		}
+		"group_by_brand": &orm.TermsAggregation{
+			Field: "brand.keyword",
+			Size:  10,
+		},
+	}
 
 	builder := NewAggreationBuilder()
 	resultJSON, err := builder.Build(request)
@@ -89,10 +89,10 @@ func TestBuild_SingleTermsAggregation(t *testing.T) {
 func TestBuild_NestedAggregation(t *testing.T) {
 	// Arrange
 	request := map[string]orm.Aggregation{
-			"products_by_type": (&orm.TermsAggregation{
-				Field: "type.keyword",
-			}).AddNested("average_price", orm.NewMetricAggregation(orm.MetricAvg, "price")),
-		}
+		"products_by_type": (&orm.TermsAggregation{
+			Field: "type.keyword",
+		}).AddNested("average_price", orm.NewMetricAggregation(orm.MetricAvg, "price")),
+	}
 
 	// Act
 	builder := NewAggreationBuilder()
@@ -127,10 +127,10 @@ func TestBuild_MultipleTopLevelAggs(t *testing.T) {
 	request := map[string]orm.Aggregation{
 		"total_sales": orm.NewMetricAggregation(orm.MetricAvg, "price"),
 		"sales_by_month": &orm.DateHistogramAggregation{
-			Field:    "order_date",
-			Interval: "1M",
+			Field:         "order_date",
+			Interval:      "1M",
 			IntervalField: elastic.CalendarInterval,
-			TimeZone: "UTC",
+			TimeZone:      "UTC",
 		},
 	}
 
@@ -185,9 +185,9 @@ type unsupportedAgg struct{ orm.TermsAggregation }
 
 // TestBuild_UnsupportedAggregationType tests that the compiler returns an error for unknown types.
 func TestBuild_UnsupportedAggregationType(t *testing.T) {
-	request :=  map[string]orm.Aggregation{
-			"bad_agg": &unsupportedAgg{},
-		}
+	request := map[string]orm.Aggregation{
+		"bad_agg": &unsupportedAgg{},
+	}
 
 	builder := NewAggreationBuilder()
 	_, err := builder.Build(request)
@@ -236,10 +236,10 @@ func TestBuild_ComplexAggregation(t *testing.T) {
 			name: "Date Histogram with Nested Terms",
 			request: map[string]orm.Aggregation{
 				"sales_over_time": (&orm.DateHistogramAggregation{
-					Field:    "sale_date",
+					Field:         "sale_date",
 					IntervalField: elastic.CalendarInterval,
-					Interval: "1M",
-					TimeZone: "UTC",
+					Interval:      "1M",
+					TimeZone:      "UTC",
 				}).AddNested("sales_by_region", (&orm.TermsAggregation{
 					Field: "region.keyword",
 				}).AddNested("avg_sale", orm.NewMetricAggregation(orm.MetricAvg, "sale_amount"))),
@@ -272,8 +272,8 @@ func TestBuild_ComplexAggregation(t *testing.T) {
 			name: "Percentiles Aggregation",
 			request: map[string]orm.Aggregation{
 				"request_over_time": (&orm.DateHistogramAggregation{
-					Field:    "timestamp",
-					Interval: "1M",
+					Field:         "timestamp",
+					Interval:      "1M",
 					IntervalField: elastic.CalendarInterval,
 				}).AddNested("response_percentiles", &orm.PercentilesAggregation{
 					Field:    "response_time",
@@ -301,9 +301,9 @@ func TestBuild_ComplexAggregation(t *testing.T) {
 			name: "complex aggregation with derivative",
 			request: map[string]orm.Aggregation{
 				"sales_over_time": (&orm.DateHistogramAggregation{
-					Field:    "sale_date",
+					Field:         "sale_date",
 					IntervalField: elastic.CalendarInterval,
-					Interval: "1M",
+					Interval:      "1M",
 				}).AddNested("avg_sale", orm.NewMetricAggregation(orm.MetricAvg, "sale_amount")).AddNested("sales_derivative", &orm.DerivativeAggregation{
 					BucketsPath: "avg_sale",
 				}),
@@ -348,15 +348,15 @@ func TestBuild_ComplexAggregation(t *testing.T) {
 func TestBuildAggsWith(t *testing.T) {
 	q := orm.NewQuery()
 	q.Must(orm.TermQuery("product_id", "12345"))
-  aggs := map[string]orm.Aggregation{
-    "sales_over_time": (&orm.DateHistogramAggregation{
-      Field:    "sale_date",
+	aggs := map[string]orm.Aggregation{
+		"sales_over_time": (&orm.DateHistogramAggregation{
+			Field:         "sale_date",
 			IntervalField: elastic.CalendarInterval,
-      Interval: "1M",
-    }).AddNested("sales_by_region", (&orm.TermsAggregation{
-      Field: "region.keyword",
-    }).AddNested("avg_sale", orm.NewMetricAggregation(orm.MetricAvg, "sale_amount"))),
-  }
+			Interval:      "1M",
+		}).AddNested("sales_by_region", (&orm.TermsAggregation{
+			Field: "region.keyword",
+		}).AddNested("avg_sale", orm.NewMetricAggregation(orm.MetricAvg, "sale_amount"))),
+	}
 	q.Aggs = aggs
 	dsl := BuildQueryDSL(q)
 	expected := `{"aggs":{"sales_over_time":{"date_histogram":{"field":"sale_date","calendar_interval":"1M"},"aggs":{"sales_by_region":{"terms":{"field":"region.keyword"},"aggs":{"avg_sale":{"avg":{"field":"sale_amount"}}}}}}},"query":{"term":{"product_id":{"value":"12345"}}}}`
@@ -431,13 +431,13 @@ func TestParseTopHitsAggregation(t *testing.T) {
 		}
 	}`
 	assertJSONEquals(t, util.MustToJSONBytes(result), expected)
-} 
+}
 
 func TestParseDateRangeAggregation(t *testing.T) {
 	builder := NewAggreationBuilder()
 	dateRangeAgg := &orm.DateRangeAggregation{
-		Field:  "timestamp",
-		Format: "yyyy-MM-dd",
+		Field:    "timestamp",
+		Format:   "yyyy-MM-dd",
 		TimeZone: "UTC",
 		Ranges: []interface{}{
 			map[string]interface{}{"to": "2006-01-01"},


### PR DESCRIPTION
## What does this PR do
This pull request introduces several enhancements and fixes to the ORM and Elasticsearch integration, focusing on improved query support, aggregation flexibility, and better compatibility with Elasticsearch APIs. The most significant changes include adding support for the `query_string` query type, extending pipeline aggregations, and refining date histogram interval handling.

**Query Enhancements**

* Added support for the `query_string` query type in the ORM, including the ability to specify fields and the default operator. This is reflected in both the core query logic and the associated tests. [[1]](diffhunk://#diff-ebb7889b112ada31833848599efde6aa9529009602a63633bf6fae0e555a49b8R54) [[2]](diffhunk://#diff-ebb7889b112ada31833848599efde6aa9529009602a63633bf6fae0e555a49b8R340-R345) [[3]](diffhunk://#diff-b293139db39789921da12c55c8b625f56d51aa2608c56ea3e04813d6fba3292cR458-R470) [[4]](diffhunk://#diff-789301c49c94854aad1d120bfc4bb4ecf20b1d75805736976e074da2c72ed772R194-R203) [[5]](diffhunk://#diff-acb1c0d641a96c3ec118706255fa2b95f8948df55db57cd476dab42d6a745231R410-R431) [[6]](diffhunk://#diff-6a5ab1b382c7b8d732e1667c4b8b236b020871d8f02badb577c84a938e5826f5L16-R16)
* Improved merging logic for boolean queries in the DSL layer, ensuring more predictable and correct behavior when combining queries. [[1]](diffhunk://#diff-b293139db39789921da12c55c8b625f56d51aa2608c56ea3e04813d6fba3292cL80-L133) [[2]](diffhunk://#diff-acb1c0d641a96c3ec118706255fa2b95f8948df55db57cd476dab42d6a745231L1291-R1345)

**Aggregation Improvements**

* Introduced the `PipelineAggregation` type and support for the `sum_bucket` pipeline aggregation, allowing for more advanced aggregation pipelines. [[1]](diffhunk://#diff-b02668fd9e879e709ba2d5027cd929b0f75d5a17889f2b4a012f86ec7331046eR56) [[2]](diffhunk://#diff-b02668fd9e879e709ba2d5027cd929b0f75d5a17889f2b4a012f86ec7331046eR128-R147) [[3]](diffhunk://#diff-370e915ad27a2e1e6689ff98de48eadd549f65dd008942677cc2862a67fa4c84L44-R48) [[4]](diffhunk://#diff-370e915ad27a2e1e6689ff98de48eadd549f65dd008942677cc2862a67fa4c84R68-R74)
* Enhanced the `DateHistogramAggregation` to allow explicit specification of the interval field (`interval`, `calendar_interval`, or `fixed_interval`), improving compatibility with different Elasticsearch versions and APIs. [[1]](diffhunk://#diff-2dc356daef83b67323d0cb4fec7463aa4451e82f2a490dd8fd62770628b2387fL145-R166) [[2]](diffhunk://#diff-b02668fd9e879e709ba2d5027cd929b0f75d5a17889f2b4a012f86ec7331046eR161) [[3]](diffhunk://#diff-370e915ad27a2e1e6689ff98de48eadd549f65dd008942677cc2862a67fa4c84R145-R168) [[4]](diffhunk://#diff-ab132b53c5d59a92a7a49027f2c28a2573dab5d1800ea14cdce9eec9fab0dd00R239) [[5]](diffhunk://#diff-ab132b53c5d59a92a7a49027f2c28a2573dab5d1800ea14cdce9eec9fab0dd00R276) [[6]](diffhunk://#diff-ab132b53c5d59a92a7a49027f2c28a2573dab5d1800ea14cdce9eec9fab0dd00R304)

**General Refactoring and Documentation**

* Updated imports for consistency and maintainability across several files. [[1]](diffhunk://#diff-2dc356daef83b67323d0cb4fec7463aa4451e82f2a490dd8fd62770628b2387fL27-R29) [[2]](diffhunk://#diff-789301c49c94854aad1d120bfc4bb4ecf20b1d75805736976e074da2c72ed772L28-R32) [[3]](diffhunk://#diff-370e915ad27a2e1e6689ff98de48eadd549f65dd008942677cc2862a67fa4c84R29) [[4]](diffhunk://#diff-ab132b53c5d59a92a7a49027f2c28a2573dab5d1800ea14cdce9eec9fab0dd00R31) [[5]](diffhunk://#diff-acb1c0d641a96c3ec118706255fa2b95f8948df55db57cd476dab42d6a745231R29-L35)
* Added release note documenting support for the new `query_string` query type.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation