### PR TITLE
feat: support custom write operation type for indexing_merge processor

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -17,6 +17,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add support for `query_string` query
 - feat: allow to read http request body multi-times #212
 - feat: add support for Elasticsearch cat allocation API
+- feat: support custom write operation type for indexing_merge processor
 
 ### 🐛 Bug fix  
 - fix: localhost/127.0.0.1 with noproxy #185

--- a/plugins/elastic/indexing_merge/indexing_merge.go
+++ b/plugins/elastic/indexing_merge/indexing_merge.go
@@ -78,6 +78,7 @@ type Config struct {
 
 	IndexName string `config:"index_name"`
 	TypeName  string `config:"type_name"`
+	WriteOpType string `config:"write_op_type"` //create, index, update
 
 	KeyField string `config:"key_field"` //the field name used as document's primary key aka `_id
 
@@ -272,11 +273,16 @@ READ_DOCS:
 				}
 				id_part = fmt.Sprintf(", \"_id\":\"%v\"", v)
 			}
+			// default to index
+			writeOpType := "index"
+			if processor.config.WriteOpType != "" {
+				writeOpType = processor.config.WriteOpType
+			}
 
 			if processor.config.TypeName != "" {
-				docBuf.WriteString(fmt.Sprintf("{ \"index\" : { \"_index\" : \"%s\", \"_type\" : \"%s\" %v } }\n", processor.config.IndexName, processor.config.TypeName, id_part))
+				docBuf.WriteString(fmt.Sprintf("{ \"%s\" : { \"_index\" : \"%s\", \"_type\" : \"%s\" %v } }\n", writeOpType, processor.config.IndexName, processor.config.TypeName, id_part))
 			} else {
-				docBuf.WriteString(fmt.Sprintf("{ \"index\" : { \"_index\" : \"%s\"  %v } }\n", processor.config.IndexName, id_part))
+				docBuf.WriteString(fmt.Sprintf("{ \"%s\" : { \"_index\" : \"%s\"  %v } }\n", writeOpType, processor.config.IndexName, id_part))
 			}
 
 			util.WalkBytesAndReplace(pop, util.NEWLINE, util.SPACE)


### PR DESCRIPTION
## What does this PR do
This pull request adds support for customizing the write operation type in the `indexing_merge` processor for Elasticsearch. This allows users to specify whether documents should be created, indexed, or updated during bulk operations, increasing flexibility for different use cases.

Enhancements to indexing_merge processor:

* Added a new `WriteOpType` configuration field to the `Config` struct in `indexing_merge.go`, allowing users to specify the write operation type (e.g., `create`, `index`, `update`).
* Modified the document construction logic to use the configured `WriteOpType` instead of always defaulting to `index`. If not specified, it defaults to `index` for backward compatibility.

Documentation updates:

* Updated the release notes to mention support for custom write operation type in the `indexing_merge` processor.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation