### PR TITLE
feat(pipeline,queue): per-processor stats, typed queue enforcement, kafka stats degradation, indexing_merge key_fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ generated_*.go
 .claude/
 
 # sqlite test artifacts
+
+# keystore runtime artifacts
+core/elastic/.keystore/

--- a/core/pipeline/processor.go
+++ b/core/pipeline/processor.go
@@ -42,12 +42,14 @@ package pipeline
 import (
 	"runtime"
 	"strings"
+	"time"
 
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/errors"
 	"infini.sh/framework/core/event"
 	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/stats"
 )
 
 type ProcessorBase interface {
@@ -266,9 +268,17 @@ func (procs *Processors) Process(ctx *Context) error {
 		log.Trace("pipeline: ", ctx.Config.Name, ", start processing:", ctx.processHistory, "->", p.Name())
 
 		ctx.AddFlowProcess(p.Name())
+		start := time.Now()
 		err := p.Process(ctx)
+		// Per-processor call stats (stats "pipeline" category, flat key =
+		// pipeline.processor.metric): source for the rate/error/latency of
+		// the processing stage under chain pressure. Stats writes are
+		// buffered, safe on the hot path.
+		stats.Increment("pipeline", ctx.Config.Name, "processor", p.Name(), "total_process")
+		stats.IncrementBy("pipeline", "processor_cost."+ctx.Config.Name+"."+p.Name(), time.Since(start).Microseconds())
 		//event, err = p.Filter(filterCfg,ctx)
 		if err != nil {
+			stats.Increment("pipeline", ctx.Config.Name, "processor", p.Name(), "total_error")
 			log.Error("error on processing:", p.Name(), ",", err)
 			return err
 		}

--- a/core/queue/queue_config.go
+++ b/core/queue/queue_config.go
@@ -168,6 +168,24 @@ func GetOrInitConfig(key string) *QueueConfig {
 	return AdvancedGetOrInitConfig("", key, nil)
 }
 
+// EnsureTypedConfig ensures the named queue is registered with the given
+// queueType. Dynamically created queues fall back to the default handler
+// (disk); transport segments that must switch the backend explicitly (e.g. a
+// kafka bus) use this to force the type, overwriting the registration in
+// place when an existing config carries a different type.
+func EnsureTypedConfig(queueType, key string) *QueueConfig {
+	if queueType == "" {
+		return GetOrInitConfig(key)
+	}
+	cfg := AdvancedGetOrInitConfig(queueType, key, nil)
+	if cfg != nil && cfg.Type != queueType {
+		cfg.Type = queueType
+		RegisterConfig(cfg)
+		log.Infof("queue [%v] switched to type [%v]", key, queueType)
+	}
+	return cfg
+}
+
 func SmartGetOrInitConfig(cfg *QueueConfig) *QueueConfig {
 	if cfg.ID != "" {
 		v, _ := GetConfigByUUID(cfg.ID)

--- a/modules/queue/api.go
+++ b/modules/queue/api.go
@@ -145,7 +145,11 @@ func (module *API) QueueStatsAction(w http.ResponseWriter, req *http.Request, ps
 		for _, q := range qs {
 			err := module.getQueueStats(t, q, metadata, consumer, useKey, data)
 			if err != nil {
-				panic(err)
+				// A single queue failing its stats (e.g. offset/depth errors
+				// when a kafka broker is unreachable) must not take down the
+				// whole stats endpoint — skip that queue, return the rest.
+				_ = log.Errorf("queue [%v] stats failed, skipped: %v", q, err)
+				continue
 			}
 		}
 		log.Tracef("queue [%v] stats: %v", t, data)

--- a/modules/queue/api.go
+++ b/modules/queue/api.go
@@ -76,7 +76,12 @@ func (module *API) SingleQueueStatsAction(w http.ResponseWriter, req *http.Reque
 	useKey := module.Get(req, "use_key", "false")
 
 	data := util.MapStr{}
-	module.getQueueStats("", ps.MustGetParameter("id"), metadata, consumer, useKey, data)
+	err := module.getQueueStatsSafe("", ps.MustGetParameter("id"), metadata, consumer, useKey, data)
+	if err != nil {
+		data["error"] = err.Error()
+		module.WriteJSON(w, data, http.StatusInternalServerError)
+		return
+	}
 	module.WriteJSON(w, data, 200)
 }
 
@@ -143,12 +148,14 @@ func (module *API) QueueStatsAction(w http.ResponseWriter, req *http.Request, ps
 	for t, qs := range queues {
 		data := util.MapStr{}
 		for _, q := range qs {
-			err := module.getQueueStats(t, q, metadata, consumer, useKey, data)
+			err := module.getQueueStatsSafe(t, q, metadata, consumer, useKey, data)
 			if err != nil {
-				// A single queue failing its stats (e.g. offset/depth errors
+				// A single queue failing its stats (e.g. offset/depth panics
 				// when a kafka broker is unreachable) must not take down the
-				// whole stats endpoint — skip that queue, return the rest.
+				// whole stats endpoint — mark that queue with an error entry,
+				// return the rest.
 				_ = log.Errorf("queue [%v] stats failed, skipped: %v", q, err)
+				data[q] = util.MapStr{"error": err.Error()}
 				continue
 			}
 		}
@@ -158,6 +165,19 @@ func (module *API) QueueStatsAction(w http.ResponseWriter, req *http.Request, ps
 	module.WriteJSON(w, util.MapStr{
 		"queue": datas,
 	}, 200)
+}
+
+// getQueueStatsSafe wraps getQueueStats with a recover: queue handlers may
+// panic on remote stats failures (e.g. kafka Depth/LatestOffset/GetOffset on
+// an unreachable broker), and one broken queue must not take down the whole
+// stats endpoint. The panic is converted into a per-queue error instead.
+func (module *API) getQueueStatsSafe(t, q string, metadata string, consumer string, useKey string, data util.MapStr) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Errorf("queue [%v] stats failed: %v", q, r)
+		}
+	}()
+	return module.getQueueStats(t, q, metadata, consumer, useKey, data)
 }
 
 func (module *API) getQueueStats(t, q string, metadata string, consumer string, useKey string, data util.MapStr) error {

--- a/plugins/elastic/indexing_merge/indexing_merge.go
+++ b/plugins/elastic/indexing_merge/indexing_merge.go
@@ -41,6 +41,7 @@ package indexing_merge
 
 import (
 	"fmt"
+	"hash/fnv"
 	"runtime"
 	"sync"
 	"time"
@@ -81,6 +82,13 @@ type Config struct {
 	WriteOpType string `config:"write_op_type"` //create, index, update
 
 	KeyField string `config:"key_field"` //the field name used as document's primary key aka `_id
+
+	// KeyFields builds a deterministic `_id` by concatenating the values of
+	// the given dot-path fields (missing paths contribute a `\x00` marker)
+	// and hashing them. Combined with write_op_type=create this makes
+	// at-least-once replays idempotent: duplicated deliveries hit ES version
+	// conflicts (409, non-retryable) instead of being indexed again.
+	KeyFields []string `config:"key_fields"`
 
 	Elasticsearch string `config:"elasticsearch"`
 
@@ -260,7 +268,9 @@ READ_DOCS:
 			}
 
 			var id_part = ""
-			if processor.config.KeyField != "" {
+			if len(processor.config.KeyFields) > 0 {
+				id_part = fmt.Sprintf(", \"_id\":\"%v\"", processor.fingerprintID(pop))
+			} else if processor.config.KeyField != "" {
 				source := util.MapStr{}
 				err := util.FromJSONBytes(pop, &source)
 				if err != nil {
@@ -417,4 +427,46 @@ func normalizeDataStreamDoc(doc []byte) []byte {
 		}
 	}
 	return util.MustToJSONBytes(out)
+}
+
+// fingerprintID derives a deterministic document id: the configured dot-path
+// fields are looked up in the queue message, joined and hashed (FNV-1a 64).
+// When NONE of the fields resolve, the raw message bytes are hashed instead —
+// the fallback keeps distinct documents apart for sources lacking e.g. file
+// metadata. Deterministic ids make at-least-once replays idempotent when
+// combined with write_op_type=create: duplicated deliveries turn into
+// ES version conflicts instead of duplicate documents.
+//
+// NOTE the fields must be stable across redeliveries: per-attempt stamps like
+// ingest timestamps change between retries and defeat dedup; content-derived
+// or source-location fields (file path/offset) do not.
+func (processor *IndexingMergeProcessor) fingerprintID(pop []byte) string {
+	h := fnv.New64a()
+
+	source := util.MapStr{}
+	if err := util.FromJSONBytes(pop, &source); err != nil {
+		// undecodable message - hash the raw bytes as-is
+		h.Write(pop)
+		return fmt.Sprintf("%x", h.Sum64())
+	}
+
+	matched := false
+	for _, f := range processor.config.KeyFields {
+		h.Write([]byte{'|'})
+		v, err := source.GetValue(f)
+		if err != nil || v == nil {
+			// keep positional meaning for missing fields
+			h.Write([]byte("\x00"))
+			continue
+		}
+		matched = true
+		h.Write([]byte(util.ToString(v)))
+	}
+	if !matched {
+		// none of the key fields exist on this message: fall back to a
+		// content hash so unrelated messages don't collapse into one id
+		h.Reset()
+		h.Write(pop)
+	}
+	return fmt.Sprintf("%x", h.Sum64())
 }

--- a/plugins/elastic/indexing_merge/indexing_merge_test.go
+++ b/plugins/elastic/indexing_merge/indexing_merge_test.go
@@ -80,3 +80,64 @@ func TestNormalizeDataStreamDocBareDoc(t *testing.T) {
 		t.Fatalf("bare doc missing timestamp stamps: %v", doc)
 	}
 }
+
+// TestFingerprintID: deterministic id from dot-path fields — same values
+// hash identically, different content diverges; when no key field resolves
+// the raw message bytes are hashed instead so distinct docs stay distinct.
+func TestFingerprintID(t *testing.T) {
+	newProc := func(fields ...string) *IndexingMergeProcessor {
+		p := &IndexingMergeProcessor{}
+		p.config.KeyFields = fields
+		return p
+	}
+
+	envelope := func(offset string) []byte {
+		return []byte(`{
+			"metadata":{"file":{"path":"/data/tmdb.csv","offset":` + offset + `}},
+			"timestamp":"2026-08-27T04:20:21.349133Z",
+			"payload":{"message":"row content"}
+		}`)
+	}
+
+	proc := newProc("metadata.file.path", "metadata.file.offset")
+
+	id1 := proc.fingerprintID(envelope("2028"))
+	if len(id1) == 0 {
+		t.Fatal("empty fingerprint")
+	}
+	if again := proc.fingerprintID(envelope("2028")); again != id1 {
+		t.Fatalf("not deterministic: %v vs %v", id1, again)
+	}
+	if id2 := proc.fingerprintID(envelope("5698")); id2 == id1 {
+		t.Fatal("different offset should yield different id")
+	}
+
+	// same file/offset but drifted ingest stamp must NOT change the id —
+	// retransmitted events get re-stamped, that's what dedup has to survive
+	drifted := []byte(`{
+		"metadata":{"file":{"path":"/data/tmdb.csv","offset":2028}},
+		"timestamp":"2026-08-27T04:20:31.000000Z",
+		"payload":{"message":"row content"}
+	}`)
+	if id3 := proc.fingerprintID(drifted); id3 != id1 {
+		t.Fatalf("id must be stable across timestamp drift: %v vs %v", id1, id3)
+	}
+
+	// no key fields present → raw-content fallback
+	fallback := newProc("metadata.file.path")
+	msgA := []byte(`{"payload":{"message":"unique-a"}}`)
+	msgB := []byte(`{"payload":{"message":"unique-b"}}`)
+	idA := fallback.fingerprintID(msgA)
+	idB := fallback.fingerprintID(msgB)
+	if idA == idB {
+		t.Fatal("fallback must keep distinct messages apart")
+	}
+	if idAA := fallback.fingerprintID(msgA); idAA != idA {
+		t.Fatal("fallback must stay deterministic")
+	}
+
+	// undecodable message → raw hash, no panic
+	if junkID := proc.fingerprintID([]byte{0xff, 0xfe, 0x01}); len(junkID) == 0 {
+		t.Fatal("undecodable input should still produce an id")
+	}
+}

--- a/plugins/queue/consumer/consumer.go
+++ b/plugins/queue/consumer/consumer.go
@@ -379,6 +379,10 @@ func (processor *QueueConsumerProcessor) HandleQueueConfig(qConfig *queue.QueueC
 			processor.wg.Add(1)
 			contextForWorker := pipeline.Context{}
 			contextForWorker.ResetContext()
+			// Inherit the owning pipeline's config (incl. Name): per-processor
+			// stats of message-level sub-chains (stats "pipeline" category)
+			// attribute to a pipeline via ctx.Config.Name.
+			contextForWorker.Config = ctx.Config
 			err := processor.pool.Submit(&pipeline.Task{
 				Handler: func(ctx *pipeline.Context, v ...interface{}) {
 					processor.NewSlicedWorker(ctx, v...)
@@ -667,6 +671,7 @@ READ_DOCS:
 
 			newCtx := pipeline.Context{}
 			newCtx.ParentContext = ctx
+			newCtx.Config = ctx.Config
 			newCtx.Context = ctx.Context
 			newCtx.Data = ctx.CloneData()
 

--- a/plugins/queue/consumer/consumer.go
+++ b/plugins/queue/consumer/consumer.go
@@ -66,7 +66,12 @@ type Config struct {
 	MaxConnectionPerHost    int                    `config:"max_connection_per_node"`
 	QueueLabels             map[string]interface{} `config:"queues,omitempty"`
 	Selector                queue.QueueSelector    `config:"queue_selector"`
-	Consumer                *queue.ConsumerConfig  `config:"consumer"`
+	// ForceQueueType enforces the backend type (e.g. kafka) of the queues
+	// consumed by this processor. Used by cross-instance transport segments:
+	// the writer (Agent) and the reader (Gateway) must land on the same
+	// queue implementation.
+	ForceQueueType string                `config:"force_queue_type"`
+	Consumer       *queue.ConsumerConfig `config:"consumer"`
 	MaxWorkers              int                    `config:"max_worker_size"`
 	DetectActiveQueue       bool                   `config:"detect_active_queue"`
 	DetectIntervalInMs      int                    `config:"detect_interval"`
@@ -209,6 +214,17 @@ func (processor *QueueConsumerProcessor) Process(c *pipeline.Context) error {
 		}
 		log.Debug("exit consumer processor")
 	}()
+
+	// Force the type: before detection/consumption, register the queues
+	// matched by the selector as the specified backend (auto-created on
+	// first use; an existing config with a different type is overwritten),
+	// so both ends land on the same implementation.
+	if processor.config.ForceQueueType != "" {
+		for _, k := range processor.config.Selector.Keys {
+			queue.EnsureTypedConfig(processor.config.ForceQueueType, k)
+			log.Infof("consumer [%v] enforces queue [%v] to type [%v]", processor.id, k, processor.config.ForceQueueType)
+		}
+	}
 
 	//handle updates
 	if processor.config.DetectActiveQueue {

--- a/plugins/queue/kafka_queue/kafka.go
+++ b/plugins/queue/kafka_queue/kafka.go
@@ -413,11 +413,15 @@ func (this *KafkaQueue) Depth(q string) int64 {
 
 	so, err := this.adminClient.ListStartOffsets(ctx, q)
 	if err != nil {
-		panic(err)
+		// broker unreachable etc: degrade the stats path to 0 instead of
+		// panicking (keep /queue/stats alive).
+		log.Error(q, ", error on get start offset (depth degraded to 0):", err)
+		return 0
 	}
 	eo, err := this.adminClient.ListEndOffsets(ctx, q)
 	if err != nil {
-		panic(err)
+		log.Error(q, ", error on get end offset (depth degraded to 0):", err)
+		return 0
 	}
 	return eo.Offsets()[q][0].At - so.Offsets()[q][0].At
 }
@@ -429,8 +433,8 @@ func (this *KafkaQueue) LatestOffset(k *queue.QueueConfig) queue.Offset {
 
 	offset1, err := this.adminClient.ListEndOffsets(ctx, k.ID)
 	if err != nil {
-		log.Error(k.Name, ", error on get offset:", offset1)
-		panic(err)
+		log.Error(k.Name, ", error on get offset (degraded to 0):", err)
+		return queue.NewOffset(0, 0)
 	}
 	return queue.NewOffset(0, offset1[k.ID][0].Offset)
 }
@@ -476,7 +480,10 @@ func (this *KafkaQueue) GetOffset(k *queue.QueueConfig, consumer *queue.Consumer
 			}
 			return queue.NewOffset(0, 0), nil
 		}
-		panic(err)
+		// broker unreachable etc: degrade the stats path to 0 instead of
+		// panicking (keep /queue/stats alive).
+		log.Error(k.ID, ", error on get consumer offset (degraded to 0):", err)
+		return queue.NewOffset(0, 0), nil
 	}
 
 	var offset int64 = 0

--- a/plugins/queue/kafka_queue/kafka.go
+++ b/plugins/queue/kafka_queue/kafka.go
@@ -413,15 +413,11 @@ func (this *KafkaQueue) Depth(q string) int64 {
 
 	so, err := this.adminClient.ListStartOffsets(ctx, q)
 	if err != nil {
-		// broker unreachable etc: degrade the stats path to 0 instead of
-		// panicking (keep /queue/stats alive).
-		log.Error(q, ", error on get start offset (depth degraded to 0):", err)
-		return 0
+		panic(err)
 	}
 	eo, err := this.adminClient.ListEndOffsets(ctx, q)
 	if err != nil {
-		log.Error(q, ", error on get end offset (depth degraded to 0):", err)
-		return 0
+		panic(err)
 	}
 	return eo.Offsets()[q][0].At - so.Offsets()[q][0].At
 }
@@ -433,8 +429,8 @@ func (this *KafkaQueue) LatestOffset(k *queue.QueueConfig) queue.Offset {
 
 	offset1, err := this.adminClient.ListEndOffsets(ctx, k.ID)
 	if err != nil {
-		log.Error(k.Name, ", error on get offset (degraded to 0):", err)
-		return queue.NewOffset(0, 0)
+		log.Error(k.Name, ", error on get offset:", offset1)
+		panic(err)
 	}
 	return queue.NewOffset(0, offset1[k.ID][0].Offset)
 }
@@ -480,10 +476,7 @@ func (this *KafkaQueue) GetOffset(k *queue.QueueConfig, consumer *queue.Consumer
 			}
 			return queue.NewOffset(0, 0), nil
 		}
-		// broker unreachable etc: degrade the stats path to 0 instead of
-		// panicking (keep /queue/stats alive).
-		log.Error(k.ID, ", error on get consumer offset (degraded to 0):", err)
-		return queue.NewOffset(0, 0), nil
+		panic(err)
 	}
 
 	var offset int64 = 0


### PR DESCRIPTION
## Summary
6 commits on top of main, pushed for review. Gateway and LogPilot already build against this state.

### Queue & pipeline
- **175867bd** typed queue coercion + force_queue_type on consumer
- **5b3a08b4** indexing_merge key_fields deterministic _id for idempotent replays (+tests)
- **490d1f0d** per-processor stats for chain-pressure visibility
- **967e8228** chore: ignore core/elastic/.keystore (runtime artifact of cluster-secrets tests)
- **8bdbd185 + 25f93242** kafka stats handling on broker outage: the earlier degrade-to-zero approach (8bdbd185) is fully reverted in 25f93242 — Depth/LatestOffset/GetOffset panic on kafka errors again, since their signatures cannot report failures and degrading to 0/offset(0,0) made every lag check report "no lag" during an outage. The /queue/stats endpoint stays alive via a per-queue recover (getQueueStatsSafe): a failing queue gets an error entry in the response; /queue/:id/stats responds 500 with the error.

## Test plan
- [x] `go build` on core/queue/modules/queue/plugins/queue/conditions packages
- [x] `go test ./core/queue/... ./core/conditions/... ./modules/queue/mem_queue/` — pass
- [x] Consumers (infinilabs/gateway feat branch, infinilabs/logpilot dev) build against it

⚠️ Note: local `main` cannot be pushed directly (repo rules) — hence this branch. Local checkout intentionally stays ahead; after merge it fast-forwards.
