### PR TITLE
fix(sqlite): whitelist field identifiers spliced into SQL text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ generated_*.go
 .latest_commit_hash.txt
 /plugins/enterprise/
 .claude/
+
+# sqlite test artifacts

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -38,6 +38,7 @@ Information about release notes of INFINI Framework is provided here.
 - fix: register elasticsearch instance even when version probe fails #393
 - fix: health api requires a system cluster that may not exist #393
 - fix: pipeline task not visible right after creation #393
+- fix(sqlite): whitelist field identifiers spliced into SQL text — query-supplied field names (`?filter`, `?sort`, legacy conds, GroupBy) were rendered into `json_extract` paths and ORDER BY fragments without escaping, enabling SQL injection by an authenticated caller; identifiers are now validated against a strict whitelist and invalid ones degrade to NULL (predicates match nothing, ORDER BY/GROUP BY degrade to constants) #412
 
 ### ✈️ Improvements  
 - refactor: add EventSink support to overall utilization collector #387

--- a/modules/sqlite/flattened.go
+++ b/modules/sqlite/flattened.go
@@ -106,8 +106,13 @@ func (s *tableSchema) resolver() sqliteOrm.FieldResolver {
 	}
 }
 
+// jsonExtractExpr is the resolver fallback for paths that are not promoted
+// to generated columns. It MUST go through SafeJSONPathExpr: this is the
+// boundary where request-supplied identifiers (filter=FIELD:value,
+// sort=FIELD) enter the SQL text, and only a strict whitelist keeps quotes
+// and operators out of the json_extract path string.
 func jsonExtractExpr(path string) string {
-	return fmt.Sprintf("json_extract(raw, '$.%s')", path)
+	return sqliteOrm.SafeJSONPathExpr(path)
 }
 
 // registry of flattened schemas by table name.

--- a/modules/sqlite/injection_e2e_test.go
+++ b/modules/sqlite/injection_e2e_test.go
@@ -1,0 +1,195 @@
+package sqlite
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"infini.sh/framework/core/orm"
+	"infini.sh/framework/core/util"
+)
+
+func seedItems(t *testing.T, handler *SQLiteORM) {
+	t.Helper()
+	now := time.Now()
+	items := []*TestItem{
+		{ORMObjectBase: orm.ORMObjectBase{ID: "e1", Created: &now, Updated: &now}, Name: "Alice", Status: "active", Age: 30},
+		{ORMObjectBase: orm.ORMObjectBase{ID: "e2", Created: &now, Updated: &now}, Name: "Bob", Status: "pending", Age: 25},
+		{ORMObjectBase: orm.ORMObjectBase{ID: "e3", Created: &now, Updated: &now}, Name: "Carol", Status: "active", Age: 35},
+	}
+	for _, item := range items {
+		require.NoError(t, handler.Create(nil, item))
+	}
+}
+
+func newSearchCtx() *orm.Context {
+	ctx := orm.NewContext()
+	orm.WithModel(ctx, &TestItem{})
+	return ctx
+}
+
+func countHits(t *testing.T, res *orm.SearchResult) int64 {
+	t.Helper()
+	require.NotNil(t, res)
+	var response map[string]interface{}
+	require.NoError(t, util.FromJSONBytes(res.Payload.([]byte), &response))
+	hits, _ := response["hits"].(map[string]interface{})
+	total, _ := hits["total"].(map[string]interface{})
+	value, _ := total["value"].(float64)
+	return int64(value)
+}
+
+// The original vulnerability: GET /transfer/jobs?filter=no_such_field'+OR+'1'='1:x
+// made the resolver splice the raw field into json_extract and return
+// "SQL logic error" (500), with a working boolean-blind injection behind it.
+// After the fix the same query must behave exactly like a filter on a
+// nonexistent field: valid SQL, zero rows, no error.
+func TestSQLiteORM_SearchV2_InjectionViaFilter(t *testing.T) {
+	handler, cleanup := setupTestDB(t)
+	defer cleanup()
+	seedItems(t, handler)
+
+	payloads := []string{
+		"no_such_field' OR '1'='1",
+		"a' or '1'='1') or '1'='2",
+		"id; DROP TABLE test_items--",
+		"x') UNION SELECT name FROM sqlite_master--",
+		"status' AND 1=('1",
+	}
+	for _, payload := range payloads {
+		qb := orm.NewQuery()
+		qb.Filter(orm.TermQuery(payload, "x"))
+		qb.Size(10)
+		res, err := handler.SearchV2(newSearchCtx(), qb)
+		assert.NoError(t, err, "payload %q must not produce a SQL error", payload)
+		if err == nil {
+			assert.Equal(t, int64(0), countHits(t, res), "injected filter must match nothing, payload=%q", payload)
+		}
+	}
+
+	// Regression: the table still exists and legit filters still work.
+	qb := orm.NewQuery()
+	qb.Filter(orm.TermQuery("status", "active"))
+	res, err := handler.SearchV2(newSearchCtx(), qb)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), countHits(t, res))
+}
+
+// The exact HTTP attack surface: NewQueryBuilderFromRequest parses
+// ?filter=FIELD:value and ?sort=FIELD:dir with attacker-controlled FIELD.
+func TestSQLiteORM_SearchV2_InjectionViaHTTPRequest(t *testing.T) {
+	handler, cleanup := setupTestDB(t)
+	defer cleanup()
+	seedItems(t, handler)
+
+	// raw query strings as an attacker's client would send them (spaces
+	// are fine unencoded in the query component; quotes may appear raw)
+	attacks := []string{
+		"filter=" + urlEscape("no_such_field' OR '1'='1:x") + "&size=10",
+		"sort=" + urlEscape("name' OR '1'='1:desc") + "&size=10",
+		"sort=" + urlEscape("age; DROP TABLE test_items--:asc") + "&size=10",
+		"filter=" + urlEscape("a') UNION SELECT 1--:b") + "&sort=" + urlEscape("id':desc") + "&size=10",
+	}
+	for _, rawQuery := range attacks {
+		req := httptest.NewRequest("GET", "/search?"+rawQuery, nil)
+		qb, err := orm.NewQueryBuilderFromRequest(req)
+		require.NoError(t, err, "attack %q must parse", rawQuery)
+		res, err := handler.SearchV2(newSearchCtx(), qb)
+		assert.NoError(t, err, "attack %q must not produce a SQL error", rawQuery)
+		if err == nil {
+			require.NotNil(t, res)
+		}
+	}
+
+	// Nothing was destroyed by the sort/filter payloads.
+	count, err := handler.Count(&TestItem{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+}
+
+func urlEscape(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, " ", "%20"), "'", "%27")
+}
+
+// Hostile sort fields must not error; ordering degrades to a constant while
+// legit sorts keep ordering correctly.
+func TestSQLiteORM_SearchV2_InjectionViaSort(t *testing.T) {
+	handler, cleanup := setupTestDB(t)
+	defer cleanup()
+	seedItems(t, handler)
+
+	for _, hostile := range []string{"name' OR '1'='1", "age;--", "id)"} {
+		qb := orm.NewQuery()
+		qb.SortBy(orm.Sort{Field: hostile, SortType: orm.DESC})
+		qb.Size(10)
+		res, err := handler.SearchV2(newSearchCtx(), qb)
+		assert.NoError(t, err, "hostile sort %q must not error", hostile)
+		require.NotNil(t, res)
+	}
+
+	// Legit sort still orders (age desc => ids e3,e1,e2).
+	qb := orm.NewQuery()
+	qb.SortBy(orm.Sort{Field: "age", SortType: orm.DESC})
+	res, err := handler.SearchV2(newSearchCtx(), qb)
+	require.NoError(t, err)
+	ids := requireSearchResultIDs(t, res)
+	assert.Equal(t, []string{"e3", "e1", "e2"}, ids)
+}
+
+// DeleteByQuery with an injected field must delete nothing — the injection
+// must never escalate from a read to data loss.
+func TestSQLiteORM_DeleteByQuery_InjectionDeletesNothing(t *testing.T) {
+	handler, cleanup := setupTestDB(t)
+	defer cleanup()
+	seedItems(t, handler)
+
+	qb := orm.NewQuery()
+	qb.Filter(orm.TermQuery("no_such_field' OR '1'='1", "x"))
+	resp, err := handler.DeleteByQuery(newSearchCtx(), qb)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int64(0), resp.Deleted, "injected filter must not match (let alone delete) anything")
+
+	count, err := handler.Count(&TestItem{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+}
+
+// GroupBy's group field is also a raw identifier site.
+func TestSQLiteORM_GroupBy_Injection(t *testing.T) {
+	handler, cleanup := setupTestDB(t)
+	defer cleanup()
+	seedItems(t, handler)
+
+	err, groups := handler.GroupBy(&TestItem{}, "", "status' OR '1'='1", "", nil)
+	assert.NoError(t, err, "hostile group field must not error")
+	require.NotNil(t, groups)
+	// The degraded NULL expression groups everything into the empty-string
+	// bucket — no leaked breakout, no SQL error.
+	assert.Equal(t, int64(3), groups[""])
+
+	// Legit grouping still works.
+	err, groups = handler.GroupBy(&TestItem{}, "", "status", "", nil)
+	assert.NoError(t, err)
+	require.NotNil(t, groups)
+	assert.Equal(t, int64(2), groups["active"])
+	assert.Equal(t, int64(1), groups["pending"])
+}
+
+// buildLegacyWhere (legacy Search API conds) neutralizes hostile fields too.
+func TestBuildLegacyWhere_Injection(t *testing.T) {
+	conds := []*orm.Cond{
+		{Field: "no_such_field' OR '1'='1", QueryType: orm.Match, Value: "x"},
+		{Field: "ok", QueryType: orm.Match, Value: "y"},
+	}
+	clauses, args := buildLegacyWhere(conds)
+	require.NotEmpty(t, clauses)
+	joined := strings.Join(clauses, " AND ")
+	assert.Contains(t, joined, "NULL")
+	assert.NotContains(t, joined, "'1'='1")
+	assert.Equal(t, "y", args[len(args)-1])
+}

--- a/modules/sqlite/orm.go
+++ b/modules/sqlite/orm.go
@@ -378,7 +378,7 @@ func (handler *SQLiteORM) Search(t interface{}, q *api.Query) (error, api.Result
 	if q.Sort != nil && len(*q.Sort) > 0 {
 		var sorts []string
 		for _, s := range *q.Sort {
-			sorts = append(sorts, fmt.Sprintf("json_extract(raw, '$.%s') %s", s.Field, string(s.SortType)))
+			sorts = append(sorts, fmt.Sprintf("%s %s", sqliteOrm.SafeJSONPathExpr(s.Field), sqliteOrm.SafeSortDirection(string(s.SortType))))
 		}
 		sqlStr += " ORDER BY " + strings.Join(sorts, ", ")
 	}
@@ -456,7 +456,7 @@ func (handler *SQLiteORM) SearchWithResultItemMapper(resultArray interface{}, it
 	if q.Sort != nil && len(*q.Sort) > 0 {
 		var sorts []string
 		for _, s := range *q.Sort {
-			sorts = append(sorts, fmt.Sprintf("json_extract(raw, '$.%s') %s", s.Field, string(s.SortType)))
+			sorts = append(sorts, fmt.Sprintf("%s %s", sqliteOrm.SafeJSONPathExpr(s.Field), sqliteOrm.SafeSortDirection(string(s.SortType))))
 		}
 		sqlStr += " ORDER BY " + strings.Join(sorts, ", ")
 	}
@@ -508,8 +508,8 @@ func (handler *SQLiteORM) SearchWithResultItemMapper(resultArray interface{}, it
 func (handler *SQLiteORM) GroupBy(t interface{}, selectField, groupField string, haveQuery string, haveValue interface{}) (error, map[string]interface{}) {
 	tableName := handler.GetIndexName(t)
 
-	sqlStr := fmt.Sprintf("SELECT json_extract(raw, '$.%s') as grp, COUNT(*) as cnt FROM [%s] GROUP BY grp",
-		groupField, tableName)
+	sqlStr := fmt.Sprintf("SELECT %s as grp, COUNT(*) as cnt FROM [%s] GROUP BY grp",
+		sqliteOrm.SafeJSONPathExpr(groupField), tableName)
 	if haveQuery != "" {
 		sqlStr += fmt.Sprintf(" HAVING %s", haveQuery)
 	}
@@ -526,12 +526,15 @@ func (handler *SQLiteORM) GroupBy(t interface{}, selectField, groupField string,
 
 	finalResult := map[string]interface{}{}
 	for rows.Next() {
-		var key string
+		// NULL group keys (empty table, or a field that degraded to NULL
+		// via SafeJSONPathExpr) scan into the empty-string bucket instead
+		// of erroring.
+		var key sql.NullString
 		var count int64
 		if err := rows.Scan(&key, &count); err != nil {
 			return err, nil
 		}
-		finalResult[key] = count
+		finalResult[key.String] = count
 	}
 	return nil, finalResult
 }
@@ -607,7 +610,7 @@ func (handler *SQLiteORM) SearchV2(ctx *api.Context, qb *api.QueryBuilder) (*api
 				if s.Field == "_score" {
 					expr = "id" // no scoring in sqlite; stable tiebreaker
 				}
-				sortParts = append(sortParts, fmt.Sprintf("%s %s", expr, string(s.SortType)))
+				sortParts = append(sortParts, fmt.Sprintf("%s %s", expr, sqliteOrm.SafeSortDirection(string(s.SortType))))
 			}
 			sqlStr += " ORDER BY " + strings.Join(sortParts, ", ")
 		}
@@ -785,7 +788,7 @@ func buildLegacyWhere(conds []*api.Cond) ([]string, []interface{}) {
 	var args []interface{}
 
 	for _, c := range conds {
-		jsonPath := fmt.Sprintf("json_extract(raw, '$.%s')", c.Field)
+		jsonPath := sqliteOrm.SafeJSONPathExpr(c.Field)
 		switch c.QueryType {
 		case api.Match:
 			if c.BoolType == api.MustNot {

--- a/modules/sqlite/orm/jsonpath.go
+++ b/modules/sqlite/orm/jsonpath.go
@@ -1,0 +1,74 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version. See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package orm
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	log "github.com/cihub/seelog"
+)
+
+// Field names and sort directions end up inside SQL text (json_extract
+// paths, ORDER BY fragments): they cannot be bound as query parameters.
+// Every such identifier therefore passes through the strict validators in
+// this file. Anything that fails validation degrades to a neutral
+// expression (NULL / ASC) so a hostile name can only ever produce an
+// empty/neutral query — never a syntax breakout.
+
+// jsonPathRe matches the identifiers the query layer legitimately produces:
+// dotted JSON paths of registered model fields, optionally with numeric
+// array indices (foo.bar[0]). Model fields never need quotes, spaces,
+// operators, or comment syntax — anything outside this set is hostile or
+// garbage.
+var jsonPathRe = regexp.MustCompile(`^[A-Za-z0-9_\-.\[\]]+$`)
+
+// invalidPathOnce deduplicates warnings: a poller or attacker replaying the
+// same bad identifier must not flood the log.
+var invalidPathOnce sync.Map
+
+// SafeJSONPathExpr renders path as a json_extract expression against the
+// document column. Invalid or empty paths return the literal NULL, which
+// makes predicates on them match nothing (identical to filtering on a
+// nonexistent field) and ORDER BY / GROUP BY degrade to a constant — the
+// same observable behavior as before, minus the injection.
+func SafeJSONPathExpr(path string) string {
+	if path == "" || !jsonPathRe.MatchString(path) {
+		if _, loaded := invalidPathOnce.LoadOrStore(path, true); !loaded {
+			log.Warnf("sqlite orm: rejected invalid JSON path identifier %q (possible injection attempt); "+
+				"the clause degrades to NULL and matches nothing", path)
+		}
+		return "NULL"
+	}
+	return fmt.Sprintf("json_extract(raw, '$.%s')", path)
+}
+
+// SafeSortDirection whitelists the ORDER BY direction token. Empty input
+// defaults to ASC; anything that is not exactly ASC/DESC (case-insensitive)
+// also degrades to ASC instead of being spliced into the SQL text.
+func SafeSortDirection(dir string) string {
+	switch strings.ToUpper(strings.TrimSpace(dir)) {
+	case "DESC":
+		return "DESC"
+	default:
+		return "ASC"
+	}
+}

--- a/modules/sqlite/orm/jsonpath_test.go
+++ b/modules/sqlite/orm/jsonpath_test.go
@@ -1,0 +1,96 @@
+package orm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The identifiers below mirror real model field paths: dotted JSON paths of
+// registered structs, with optional dashes and numeric array indices.
+func TestSafeJSONPathExpr_ValidPaths(t *testing.T) {
+	valid := map[string]string{
+		"status":       "json_extract(raw, '$.status')",
+		"system.name":  "json_extract(raw, '$.system.name')",
+		"a_b.c-d":      "json_extract(raw, '$.a_b.c-d')",
+		"arr[0]":       "json_extract(raw, '$.arr[0]')",
+		"x9.y-8_z":     "json_extract(raw, '$.x9.y-8_z')",
+		"metadata.ip0": "json_extract(raw, '$.metadata.ip0')",
+	}
+	for path, want := range valid {
+		assert.Equal(t, want, SafeJSONPathExpr(path), "path %q should render as json_extract", path)
+	}
+}
+
+// Every classic string-literal breakout, comment, stacked-statement and
+// format-string probe must degrade to the literal NULL. NULL in a WHERE
+// predicate matches nothing and in ORDER BY / GROUP BY is a constant — the
+// query stays valid SQL with attacker content fully neutralized.
+func TestSafeJSONPathExpr_RejectsInjection(t *testing.T) {
+	payloads := []string{
+		"",
+		"' OR '1'='1",
+		"x') OR ('1'='1",
+		"no_such_field' OR '1'='1",
+		"id; DROP TABLE transfer-jobs--",
+		"id') UNION SELECT password FROM users--",
+		"a\"b",
+		"foo bar",
+		"$(id)",
+		"`id`",
+		"%s%s%s",
+		"'); INSERT INTO x VALUES(1)--",
+		"*/ --",
+		"\\' OR 1=1--",
+		"status\u0027 OR \u00271\u0027=\u00271",
+		"путь",
+		"$.secret",
+		"line\nbreak",
+		"tab\there",
+	}
+	for _, p := range payloads {
+		got := SafeJSONPathExpr(p)
+		assert.Equal(t, "NULL", got, "payload %q must degrade to NULL", p)
+	}
+}
+
+// Whatever the input, the only quotes in a rendered expression are the
+// '$...' path delimiters themselves: any input that carries a quote, a
+// parenthesis, a semicolon or a comment marker is rejected outright, and
+// inputs that pass the whitelist cannot contain them by construction.
+func TestSafeJSONPathExpr_OutputNeverBreaksOut(t *testing.T) {
+	nasty := []string{"'", "''", "a'b", "';--", "')", "((", ")?", "%'", "\"x"}
+	for _, p := range nasty {
+		got := SafeJSONPathExpr(p)
+		assert.Equal(t, "NULL", got, "input %q carries breakout characters and must be rejected", p)
+	}
+	// And a passing identifier's output contains exactly the two delimiter
+	// quotes of the path literal, nothing more.
+	out := SafeJSONPathExpr("ok_field")
+	assert.Equal(t, 2, strings.Count(out, "'"), "only the path delimiters may be quotes: %s", out)
+}
+
+func TestSafeSortDirection(t *testing.T) {
+	assert.Equal(t, "ASC", SafeSortDirection("asc"))
+	assert.Equal(t, "ASC", SafeSortDirection("ASC"))
+	assert.Equal(t, "ASC", SafeSortDirection(""))
+	assert.Equal(t, "ASC", SafeSortDirection("  asc  "))
+	assert.Equal(t, "DESC", SafeSortDirection("desc"))
+	assert.Equal(t, "DESC", SafeSortDirection(" DESC "))
+
+	// Anything that is not a bare direction degrades to ASC instead of
+	// being spliced into the ORDER BY fragment.
+	hostile := []string{
+		"DESC; DROP TABLE x--",
+		"DESC, (SELECT password FROM users)",
+		"desc'",
+		"anything else",
+		"\u0000",
+	}
+	for _, h := range hostile {
+		got := SafeSortDirection(h)
+		assert.True(t, got == "ASC" || got == "DESC", "direction for %q must collapse to ASC/DESC, got %q", h, got)
+		assert.False(t, strings.ContainsAny(got, ";'(),"), "direction must stay a bare token, got %q", got)
+	}
+}

--- a/modules/sqlite/orm/query_builder.go
+++ b/modules/sqlite/orm/query_builder.go
@@ -61,10 +61,12 @@ func BuildWhereClause(qb *orm.QueryBuilder, resolve FieldResolver) (string, []in
 }
 
 // ExprFor resolves a JSON path to its comparison expression via the
-// resolver (generated column when promoted, json_extract otherwise).
+// resolver (generated column when promoted, json_extract otherwise). The
+// nil-resolver fallback goes through SafeJSONPathExpr so a hostile path can
+// never be spliced raw into the SQL text.
 func ExprFor(resolve FieldResolver, path string) string {
 	if resolve == nil {
-		return fmt.Sprintf("json_extract(raw, '$.%s')", path)
+		return SafeJSONPathExpr(path)
 	}
 	expr, _, _ := resolve(path)
 	return expr
@@ -72,10 +74,12 @@ func ExprFor(resolve FieldResolver, path string) string {
 
 // RangeExprFor picks the comparison expression for a range predicate: the
 // epoch shadow when one exists (the value is rewritten to integer epoch
-// seconds by the caller), else the regular expression.
+// seconds by the caller), else the regular expression. The nil-resolver
+// fallback goes through SafeJSONPathExpr so a hostile path can never be
+// spliced raw into the SQL text.
 func RangeExprFor(resolve FieldResolver, path string) (expr string, epoch bool) {
 	if resolve == nil {
-		return fmt.Sprintf("json_extract(raw, '$.%s')", path), false
+		return SafeJSONPathExpr(path), false
 	}
 	plain, epochExpr, _ := resolve(path)
 	if epochExpr != "" {

--- a/modules/sqlite/orm/query_builder_injection_test.go
+++ b/modules/sqlite/orm/query_builder_injection_test.go
@@ -1,0 +1,141 @@
+package orm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"infini.sh/framework/core/orm"
+)
+
+// injectionPayloads is the canonical attack corpus for field names. These
+// arrive from ?filter=FIELD:value and ?sort=FIELD query parameters, where
+// FIELD is fully attacker-controlled.
+var injectionPayloads = []string{
+	"no_such_field' OR '1'='1",
+	"x') OR ('1'='1",
+	"id; DROP TABLE transfer-jobs--",
+	"id') UNION SELECT access_token FROM agents--",
+	"a\"b",
+	"foo bar",
+	"status' AND json_extract(raw, '$.password') LIKE 'a",
+	"\\' OR 1=1--",
+}
+
+// hostileMarkers are fragments that must never survive into generated SQL
+// (they would mean the payload crossed the string-literal boundary or was
+// interpreted as SQL syntax).
+func assertNoBreakout(t *testing.T, where string) {
+	t.Helper()
+	lower := strings.ToLower(where)
+	for _, marker := range []string{"'1'='1", "or 1=1", "union", "drop table", ";", "--", "\""} {
+		assert.NotContains(t, lower, marker, "generated SQL contains breakout marker %q: %s", marker, where)
+	}
+}
+
+// Every leaf operator that renders a field expression must neutralize a
+// hostile field name: the expression degrades to NULL, and the value stays
+// a bound parameter.
+func TestBuildWhereClause_Injection_AllOperators(t *testing.T) {
+	type opCase struct {
+		name   string
+		clause *orm.Clause
+		values []interface{} // expected bound args (subset match, order kept)
+	}
+	for _, payload := range injectionPayloads {
+		cases := []opCase{
+			{"term", orm.TermQuery(payload, "v"), []interface{}{"v"}},
+			{"terms", orm.TermsQuery(payload, []string{"a", "b"}), []interface{}{"a", "b"}},
+			{"in", orm.InQuery(payload, []interface{}{1, 2}), []interface{}{1, 2}},
+			{"notin", orm.NotInQuery(payload, []interface{}{1}), []interface{}{1}},
+			{"match", orm.MatchQuery(payload, "v"), []interface{}{"v"}},
+			{"multimatch", orm.MultiMatchQuery([]string{payload, "other"}, "v"), []interface{}{"%v%"}},
+			{"prefix", orm.PrefixQuery(payload, "v"), []interface{}{"v%"}},
+			{"wildcard", orm.WildcardQuery(payload, "a*b"), []interface{}{"a%b"}},
+			{"regexp", orm.RegexpQuery(payload, "v"), []interface{}{"%v%"}},
+			{"exists", orm.ExistsQuery(payload), nil},
+			{"fuzzy", orm.FuzzyQuery(payload, "v", 1), []interface{}{"%v%"}},
+			{"matchphrase", orm.MatchPhraseQuery(payload, "v", 0), []interface{}{"%v%"}},
+			{"querystring", orm.QueryStringQuery(payload, "v", "AND"), []interface{}{"%v%"}},
+			{"range_gte", orm.Range(payload).Gte(10), []interface{}{10}},
+			{"range_lte", orm.Range(payload).Lte(10), []interface{}{10}},
+			{"range_gt", orm.Range(payload).Gt(10), []interface{}{10}},
+			{"range_lt", orm.Range(payload).Lt(10), []interface{}{10}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name+"/"+payload, func(t *testing.T) {
+				qb := orm.NewQuery()
+				qb.Filter(tc.clause)
+				where, args := BuildWhereClause(qb, nil)
+				if where == "" {
+					// notin on hostile can legitimately produce "NOT NULL" or
+					// empty via termsToSQL's empty branch — both are safe.
+					assert.LessOrEqual(t, len(where), 8, "unexpected SQL: %s", where)
+					return
+				}
+				assert.Contains(t, where, "NULL", "hostile field must degrade to NULL, got: %s", where)
+				assertNoBreakout(t, where)
+				for _, v := range tc.values {
+					assert.Contains(t, args, v, "value must remain a bound parameter")
+				}
+			})
+		}
+	}
+}
+
+// Compound clauses (must / filter / must_not / should) neutralize hostile
+// children the same way.
+func TestBuildWhereClause_Injection_CompoundClauses(t *testing.T) {
+	payload := "no_such_field' OR '1'='1"
+	evil := orm.TermQuery(payload, "v")
+	good := orm.TermQuery("status", "active")
+
+	qb := orm.NewQuery()
+	qb.Must(evil, good)
+	where, _ := BuildWhereClause(qb, nil)
+	assert.Contains(t, where, "NULL")
+	assert.Contains(t, where, "json_extract(raw, '$.status')")
+	assertNoBreakout(t, where)
+
+	qb = orm.NewQuery()
+	qb.Filter(orm.MustNotQuery(evil))
+	where, _ = BuildWhereClause(qb, nil)
+	assert.Contains(t, where, "NULL")
+	assertNoBreakout(t, where)
+
+	qb = orm.NewQuery()
+	qb.Should(evil, good)
+	where, _ = BuildWhereClause(qb, nil)
+	assert.Contains(t, where, "NULL")
+	assertNoBreakout(t, where)
+}
+
+// The regression guard: legitimate dotted paths still render the same SQL
+// as before the fix.
+func TestBuildWhereClause_LegitimateFieldsUnchanged(t *testing.T) {
+	qb := orm.NewQuery()
+	qb.Filter(orm.TermQuery("system.name", "x"))
+	where, args := BuildWhereClause(qb, nil)
+	assert.Equal(t, "json_extract(raw, '$.system.name') = ?", where)
+	assert.Equal(t, []interface{}{"x"}, args)
+}
+
+// A resolver that maps some fields (the schema-promoted case) must keep
+// returning its whitelisted expressions untouched, while unmapped hostile
+// paths degrade via the resolver's own fallback.
+func TestExprFor_ResolverPaths(t *testing.T) {
+	resolve := func(path string) (string, string, *FTSPlan) {
+		if path == "status" {
+			return `["status"]`, "", nil
+		}
+		return SafeJSONPathExpr(path), "", nil // mirrors tableSchema.resolver fallback
+	}
+	assert.Equal(t, `["status"]`, ExprFor(resolve, "status"))
+	assert.Equal(t, "NULL", ExprFor(resolve, "no_such_field' OR '1'='1"))
+	rangeExpr, rangeEpoch := RangeExprFor(resolve, "status")
+	assert.Equal(t, `["status"]`, rangeExpr)
+	assert.False(t, rangeEpoch)
+	hostileExpr, _ := RangeExprFor(resolve, "a' OR '1'='1")
+	assert.Equal(t, "NULL", hostileExpr)
+}


### PR DESCRIPTION
## Problem

Field names from query parameters (`?filter=FIELD:value`, `?sort=FIELD:dir`, legacy conds, GroupBy) are rendered into SQL as `json_extract` path expressions and ORDER BY fragments — they cannot be bound as parameters. A field containing a quote broke out of the path string literal, and an authenticated caller could turn that into boolean-blind SQL injection.

Verified live against an INFINI Transfer deployment:

```
?filter=nosuchfield_x:somevalue      -> 200 {"total":0}
?filter=nosuchfield_x' OR '1'='1:x   -> 500 "SQL logic error: bad JSON path: '1'"
?filter=a' or '1'='1') or '1'='2:x   -> 500 "near ')': syntax error"
```

The attacker-controlled fragments reached the SQLite parser; crafted boolean payloads can read the whole DB (cluster credentials, agent tokens).

## Fix

All seven construction sites (`ExprFor`, `RangeExprFor`, `jsonExtractExpr`, two legacy sort builders, `GroupBy`, `buildLegacyWhere`) now route through `SafeJSONPathExpr`, a strict `[A-Za-z0-9_.-]`-style whitelist:

- invalid or empty identifiers degrade to the literal `NULL` — predicates match nothing (identical to filtering on a nonexistent field), ORDER BY / GROUP BY degrade to constants;
- sort direction tokens collapse to ASC/DESC via `SafeSortDirection`;
- `GroupBy` scans NULL keys into the empty-string bucket instead of erroring;
- rejected identifiers log a deduplicated warning.

## Tests

- whitelist/blacklist units (19 hostile payloads incl. unicode, format strings, stacked statements)
- operator sweep: every leaf clause type x 8 hostile field names, asserting NULL degradation, values stay bound parameters, and no breakout markers in generated SQL
- compound clauses (must/filter/must_not/should) and resolver-path coverage
- end-to-end through the real SQLiteORM handler: SearchV2 (filter + sort + HTTP-parser level), DeleteByQuery (injection deletes nothing), GroupBy, legacy conds — plus regression tests that legitimate dotted paths behave unchanged
