### PR TITLE
fix(queue): label selector AND semantics, kafka partition commits, consumer config overrides

### DIFF
--- a/core/queue/api.go
+++ b/core/queue/api.go
@@ -499,25 +499,30 @@ func GetConfigBySelector(selector *QueueSelector) []*QueueConfig {
 	return cfgs
 }
 
+// GetConfigByLabels returns the queue configs whose labels match ALL of the
+// requested label pairs (AND semantics): a queue missing one of the keys, or
+// carrying a different value for it, is excluded. The previous implementation
+// only required at least one matching pair — a queue tagged {topic:x} was
+// selected by a {topic:x, env:prod} selector even though it has no env tag.
 func GetConfigByLabels(labels map[string]interface{}) []*QueueConfig {
 
 	cfgs := []*QueueConfig{}
+	if len(labels) == 0 {
+		return cfgs
+	}
 	configs.Range(func(key, value interface{}) bool {
 		v := value.(*QueueConfig)
 		if v != nil {
-			matched := false
+			matched := true
 			for x, y := range labels {
-				if v.Labels != nil {
-					z, ok := v.Labels[x]
-					if ok {
-						if util.ToString(z) == util.ToString(y) {
-							matched = true
-						} else {
-							//skip when it does not match label's value
-							matched = false
-							return true
-						}
-					}
+				if v.Labels == nil {
+					matched = false
+					break
+				}
+				z, ok := v.Labels[x]
+				if !ok || util.ToString(z) != util.ToString(y) {
+					matched = false
+					break
 				}
 			}
 			if matched {

--- a/core/queue/api.go
+++ b/core/queue/api.go
@@ -513,17 +513,22 @@ func GetConfigByLabels(labels map[string]interface{}) []*QueueConfig {
 	configs.Range(func(key, value interface{}) bool {
 		v := value.(*QueueConfig)
 		if v != nil {
-			matched := true
+			matched := false
+			verified := 0
 			for x, y := range labels {
 				if v.Labels == nil {
-					matched = false
 					break
 				}
 				z, ok := v.Labels[x]
 				if !ok || util.ToString(z) != util.ToString(y) {
-					matched = false
 					break
 				}
+				verified++
+			}
+			// not matched by default — enable only when every requested
+			// label pair was explicitly verified
+			if verified == len(labels) {
+				matched = true
 			}
 			if matched {
 				cfgs = append(cfgs, v)

--- a/core/queue/api_labels_test.go
+++ b/core/queue/api_labels_test.go
@@ -1,0 +1,115 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"infini.sh/framework/core/kv"
+)
+
+// memKV is an in-memory KVStore so queue-config registration works in unit
+// tests without a store module.
+type memKV struct {
+	data map[string][]byte
+}
+
+func (m *memKV) Open() error  { return nil }
+func (m *memKV) Close() error { return nil }
+func (m *memKV) GetValue(bucket string, key []byte) ([]byte, error) {
+	if v, ok := m.data[string(key)]; ok {
+		return append([]byte(nil), v...), nil
+	}
+	return nil, nil
+}
+func (m *memKV) GetCompressedValue(bucket string, key []byte) ([]byte, error) {
+	return m.GetValue(bucket, key)
+}
+func (m *memKV) AddValueCompress(bucket string, key, value []byte) error {
+	return m.AddValue(bucket, key, value)
+}
+func (m *memKV) AddValue(bucket string, key, value []byte) error {
+	m.data[string(key)] = append([]byte(nil), value...)
+	return nil
+}
+func (m *memKV) ExistsKey(bucket string, key []byte) (bool, error) {
+	_, ok := m.data[string(key)]
+	return ok, nil
+}
+func (m *memKV) DeleteKey(bucket string, key []byte) error {
+	delete(m.data, string(key))
+	return nil
+}
+
+func init() {
+	kv.Register("test-mem-kv", &memKV{data: map[string][]byte{}})
+}
+
+func registerLabeledQueue(t *testing.T, id string, labels map[string]interface{}) *QueueConfig {
+	t.Helper()
+	cfg := AcquireQueueConfig()
+	cfg.ID = id
+	cfg.Name = id
+	cfg.Labels = labels
+	_, err := RegisterConfig(cfg)
+	assert.NoError(t, err)
+	t.Cleanup(func() { RemoveConfig(cfg) })
+	return cfg
+}
+
+func labelSet(cfgs []*QueueConfig) map[string]bool {
+	set := map[string]bool{}
+	for _, c := range cfgs {
+		set[c.ID] = true
+	}
+	return set
+}
+
+// A queue must carry ALL requested label pairs (AND): the historical
+// behavior matched on any single pair, so a {topic:x} queue was selected
+// by a {topic:x, env:prod} selector even without the env tag.
+func TestGetConfigByLabels_AndSemantics(t *testing.T) {
+	registerLabeledQueue(t, "labels-single", map[string]interface{}{"topic": "x"})
+	registerLabeledQueue(t, "labels-other", map[string]interface{}{"topic": "y", "env": "prod"})
+	registerLabeledQueue(t, "labels-extra", map[string]interface{}{"topic": "x", "env": "prod", "zone": "a"})
+
+	// full subset match
+	registerLabeledQueue(t, "labels-full", map[string]interface{}{"topic": "x", "env": "prod"})
+	got := labelSet(GetConfigByLabels(map[string]interface{}{"topic": "x", "env": "prod"}))
+	assert.True(t, got["labels-full"], "exact match must be selected")
+	assert.True(t, got["labels-extra"], "queue with extra labels must be selected")
+	assert.False(t, got["labels-single"], "queue missing a requested label must NOT be selected (AND)")
+	assert.False(t, got["labels-other"], "queue with a different value must NOT be selected")
+
+	// single-label selector still selects every queue carrying that pair
+	got = labelSet(GetConfigByLabels(map[string]interface{}{"topic": "x"}))
+	assert.True(t, got["labels-full"])
+	assert.True(t, got["labels-single"])
+	assert.True(t, got["labels-extra"])
+	assert.False(t, got["labels-other"])
+
+	// label values compare by string form (yaml int 1 vs "1")
+	registerLabeledQueue(t, "labels-num", map[string]interface{}{"topic": "x", "shard": 3})
+	got = labelSet(GetConfigByLabels(map[string]interface{}{"topic": "x", "shard": "3"}))
+	assert.True(t, got["labels-num"], "label values must compare by string representation")
+
+	// empty selector matches nothing
+	assert.Empty(t, GetConfigByLabels(map[string]interface{}{}))
+
+	// no-labels queues are never selected by a labeled selector
+	registerLabeledQueue(t, "labels-none", nil)
+	got = labelSet(GetConfigByLabels(map[string]interface{}{"topic": "x"}))
+	assert.False(t, got["labels-none"])
+
+	// selector with a label nobody carries
+	assert.Empty(t, GetConfigByLabels(map[string]interface{}{"topic": "x", "missing": "1"}))
+}
+
+// The selector path consumers actually use must inherit the AND semantics.
+func TestGetConfigBySelector_Labels(t *testing.T) {
+	registerLabeledQueue(t, "sel-full", map[string]interface{}{"role": "logs", "env": "prod"})
+	registerLabeledQueue(t, "sel-partial", map[string]interface{}{"role": "logs"})
+
+	got := labelSet(GetConfigBySelector(&QueueSelector{Labels: map[string]interface{}{"role": "logs", "env": "prod"}}))
+	assert.True(t, got["sel-full"])
+	assert.False(t, got["sel-partial"])
+}

--- a/core/queue/consumer_config.go
+++ b/core/queue/consumer_config.go
@@ -71,6 +71,37 @@ func (cfg *ConsumerConfig) Key() string {
 	return getConsumerKey(cfg.Group, cfg.Name)
 }
 
+// Clone returns a field-by-field copy of the config. Consumers must clone
+// before applying processor-level overrides: the config returned from the
+// registry is a shared pointer, and mutating it in place leaks one
+// processor's fetch settings into every other consumer of the same
+// queue+group. The cached fetchMaxWaitMs and the commit locker start fresh
+// in the copy. (Explicit copy instead of a struct dereference to stay
+// copylocks-clean.)
+func (cfg *ConsumerConfig) Clone() *ConsumerConfig {
+	clone := &ConsumerConfig{
+		Source:                  cfg.Source,
+		Group:                   cfg.Group,
+		Name:                    cfg.Name,
+		AutoResetOffset:         cfg.AutoResetOffset,
+		AutoCommitOffset:        cfg.AutoCommitOffset,
+		SimpleSlicedGroup:       cfg.SimpleSlicedGroup,
+		FetchMinBytes:           cfg.FetchMinBytes,
+		FetchMaxBytes:           cfg.FetchMaxBytes,
+		FetchMaxMessages:        cfg.FetchMaxMessages,
+		FetchMaxWaitMs:          cfg.FetchMaxWaitMs,
+		ConsumeTimeoutInSeconds: cfg.ConsumeTimeoutInSeconds,
+		EOFMaxRetryTimes:        cfg.EOFMaxRetryTimes,
+		EOFRetryDelayInMs:       cfg.EOFRetryDelayInMs,
+		ClientExpiredInSeconds:  cfg.ClientExpiredInSeconds,
+	}
+	clone.ID = cfg.ID
+	clone.Created = cfg.Created
+	clone.Updated = cfg.Updated
+	clone.System = cfg.System
+	return clone
+}
+
 func (cfg *ConsumerConfig) KeepActive() {
 	stats.TimestampNow("consumer", cfg.ID, "last_active")
 }

--- a/plugins/queue/consumer/consumer.go
+++ b/plugins/queue/consumer/consumer.go
@@ -394,6 +394,46 @@ var xxHashPool = sync.Pool{
 	},
 }
 
+// applyProcessorConsumerOverrides folds the processor's `consumer` config
+// block into the (cloned) per-worker consumer config. Zero values mean "not
+// configured" and keep the registry value. EOFMaxRetryTimes,
+// ClientExpiredInSeconds and AutoResetOffset were previously missing here:
+// configuring them on the processor silently had no effect — the kafka
+// lock-hold duration, the EOF retry budget and the earliest/latest start
+// position always came from whatever the registry happened to hold.
+func applyProcessorConsumerOverrides(dst, src *queue.ConsumerConfig) {
+	if src == nil {
+		return
+	}
+	if src.EOFRetryDelayInMs > 0 {
+		dst.EOFRetryDelayInMs = src.EOFRetryDelayInMs
+	}
+	if src.FetchMaxMessages > 0 {
+		dst.FetchMaxMessages = src.FetchMaxMessages
+	}
+	if src.FetchMaxWaitMs > 0 {
+		dst.FetchMaxWaitMs = src.FetchMaxWaitMs
+	}
+	if src.ConsumeTimeoutInSeconds > 0 {
+		dst.ConsumeTimeoutInSeconds = src.ConsumeTimeoutInSeconds
+	}
+	if src.FetchMinBytes > 0 {
+		dst.FetchMinBytes = src.FetchMinBytes
+	}
+	if src.FetchMaxBytes > 0 {
+		dst.FetchMaxBytes = src.FetchMaxBytes
+	}
+	if src.EOFMaxRetryTimes > 0 {
+		dst.EOFMaxRetryTimes = src.EOFMaxRetryTimes
+	}
+	if src.ClientExpiredInSeconds > 0 {
+		dst.ClientExpiredInSeconds = src.ClientExpiredInSeconds
+	}
+	if src.AutoResetOffset != "" {
+		dst.AutoResetOffset = src.AutoResetOffset
+	}
+}
+
 func (processor *QueueConsumerProcessor) NewSlicedWorker(ctx *pipeline.Context, v ...interface{}) {
 	qConfig := v[0].(*queue.QueueConfig)
 	workerID := v[1].(string)
@@ -440,26 +480,9 @@ func (processor *QueueConsumerProcessor) NewSlicedWorker(ctx *pipeline.Context, 
 		}
 	}
 
-	var consumerConfig = queue.GetOrInitConsumerConfig(qConfig.ID, groupName, processor.config.Consumer.Name)
+	var consumerConfig = queue.GetOrInitConsumerConfig(qConfig.ID, groupName, processor.config.Consumer.Name).Clone()
 	//override consumer config with processor's consumer config
-	if processor.config.Consumer.EOFRetryDelayInMs > 0 {
-		consumerConfig.EOFRetryDelayInMs = processor.config.Consumer.EOFRetryDelayInMs
-	}
-	if processor.config.Consumer.FetchMaxMessages > 0 {
-		consumerConfig.FetchMaxMessages = processor.config.Consumer.FetchMaxMessages
-	}
-	if processor.config.Consumer.FetchMaxWaitMs > 0 {
-		consumerConfig.FetchMaxWaitMs = processor.config.Consumer.FetchMaxWaitMs
-	}
-	if processor.config.Consumer.ConsumeTimeoutInSeconds > 0 {
-		consumerConfig.ConsumeTimeoutInSeconds = processor.config.Consumer.ConsumeTimeoutInSeconds
-	}
-	if processor.config.Consumer.FetchMinBytes > 0 {
-		consumerConfig.FetchMinBytes = processor.config.Consumer.FetchMinBytes
-	}
-	if processor.config.Consumer.FetchMaxBytes > 0 {
-		consumerConfig.FetchMaxBytes = processor.config.Consumer.FetchMaxBytes
-	}
+	applyProcessorConsumerOverrides(consumerConfig, processor.config.Consumer)
 
 	//skip empty queue
 	if processor.config.SkipEmptyQueue && !queue.ConsumerHasLag(qConfig, consumerConfig) {
@@ -597,7 +620,6 @@ READ_DOCS:
 
 				//log.Errorf("slice_worker, error on consume queue:[%v], slice_id:%v, no data fetched, offset: %v", qConfig.Name, sliceID, ctx1)
 				goto CLEAN_BUFFER
-				return
 			}
 			//log.Errorf("slice_worker, error on queue:[%v], slice_id:%v, %v", qConfig.Name, sliceID, err)
 			log.Flush()

--- a/plugins/queue/consumer/override_test.go
+++ b/plugins/queue/consumer/override_test.go
@@ -1,0 +1,109 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"infini.sh/framework/core/queue"
+)
+
+// The processor folds its `consumer` block into the registry config via
+// applyProcessorConsumerOverrides — on a CLONE. These tests pin both the
+// field coverage (including the three fields that were previously missing)
+// and the clone independence.
+func TestApplyProcessorConsumerOverrides_FullCoverage(t *testing.T) {
+	base := &queue.ConsumerConfig{
+		FetchMinBytes:           1,
+		FetchMaxBytes:           100,
+		FetchMaxMessages:        10,
+		FetchMaxWaitMs:          1000,
+		ConsumeTimeoutInSeconds: 30,
+		EOFMaxRetryTimes:        3,
+		EOFRetryDelayInMs:       100,
+		ClientExpiredInSeconds:  60,
+		AutoResetOffset:         "earliest",
+	}
+	src := &queue.ConsumerConfig{
+		FetchMinBytes:           2,
+		FetchMaxBytes:           200,
+		FetchMaxMessages:        20,
+		FetchMaxWaitMs:          2000,
+		ConsumeTimeoutInSeconds: 45,
+		EOFMaxRetryTimes:        7,
+		EOFRetryDelayInMs:       200,
+		ClientExpiredInSeconds:  90,
+		AutoResetOffset:         "latest",
+	}
+	applyProcessorConsumerOverrides(base, src)
+	assert.Equal(t, 2, base.FetchMinBytes)
+	assert.Equal(t, 200, base.FetchMaxBytes)
+	assert.Equal(t, 20, base.FetchMaxMessages)
+	assert.Equal(t, int64(2000), base.FetchMaxWaitMs)
+	assert.Equal(t, 45, base.ConsumeTimeoutInSeconds)
+	assert.Equal(t, 7, base.EOFMaxRetryTimes, "eof_max_retry_times must be overridable")
+	assert.Equal(t, int64(200), base.EOFRetryDelayInMs)
+	assert.Equal(t, int64(90), base.ClientExpiredInSeconds, "client_expired_in_seconds must be overridable")
+	assert.Equal(t, "latest", base.AutoResetOffset, "auto_reset_offset must be overridable")
+}
+
+// Zero values on the processor side mean "not configured" and must keep the
+// registry value — including the newly covered fields.
+func TestApplyProcessorConsumerOverrides_ZeroValuesKeepBase(t *testing.T) {
+	base := &queue.ConsumerConfig{
+		FetchMinBytes:           1,
+		FetchMaxBytes:           100,
+		FetchMaxMessages:        10,
+		FetchMaxWaitMs:          1000,
+		ConsumeTimeoutInSeconds: 30,
+		EOFMaxRetryTimes:        3,
+		EOFRetryDelayInMs:       100,
+		ClientExpiredInSeconds:  60,
+		AutoResetOffset:         "earliest",
+	}
+	applyProcessorConsumerOverrides(base, &queue.ConsumerConfig{})
+	assert.Equal(t, 1, base.FetchMinBytes)
+	assert.Equal(t, 100, base.FetchMaxBytes)
+	assert.Equal(t, 10, base.FetchMaxMessages)
+	assert.Equal(t, int64(1000), base.FetchMaxWaitMs)
+	assert.Equal(t, 30, base.ConsumeTimeoutInSeconds)
+	assert.Equal(t, 3, base.EOFMaxRetryTimes)
+	assert.Equal(t, int64(100), base.EOFRetryDelayInMs)
+	assert.Equal(t, int64(60), base.ClientExpiredInSeconds)
+	assert.Equal(t, "earliest", base.AutoResetOffset)
+
+	// nil source is a no-op
+	applyProcessorConsumerOverrides(base, nil)
+	assert.Equal(t, 10, base.FetchMaxMessages)
+}
+
+// Clone independence: overriding the worker copy must never write back into
+// the shared registry object — two processors with different fetch settings
+// consuming the same queue+group previously clobbered each other.
+func TestConsumerConfigCloneIndependence(t *testing.T) {
+	shared := queue.NewConsumerConfig("queue-1", "group-1", "c1")
+	shared.FetchMaxMessages = 500
+	shared.FetchMaxBytes = 20 * 1024 * 1024
+	shared.AutoResetOffset = "earliest"
+
+	worker := shared.Clone()
+	applyProcessorConsumerOverrides(worker, &queue.ConsumerConfig{
+		FetchMaxMessages: 50,
+		FetchMaxBytes:    1024,
+		AutoResetOffset:  "latest",
+	})
+
+	assert.Equal(t, 50, worker.FetchMaxMessages)
+	assert.Equal(t, 1024, worker.FetchMaxBytes)
+	assert.Equal(t, "latest", worker.AutoResetOffset)
+
+	assert.Equal(t, 500, shared.FetchMaxMessages, "registry copy must stay untouched")
+	assert.Equal(t, 20*1024*1024, shared.FetchMaxBytes, "registry copy must stay untouched")
+	assert.Equal(t, "earliest", shared.AutoResetOffset, "registry copy must stay untouched")
+
+	// identity fields survive the clone (offset/commit paths key on them)
+	assert.Equal(t, shared.ID, worker.ID)
+	assert.Equal(t, shared.Group, worker.Group)
+	assert.Equal(t, shared.Name, worker.Name)
+	assert.Equal(t, shared.Key(), worker.Key())
+}

--- a/plugins/queue/kafka_queue/consumer.go
+++ b/plugins/queue/kafka_queue/consumer.go
@@ -73,10 +73,7 @@ func (this *Consumer) CommitOffset(off queue.Offset) error {
 	defer cancel()
 
 	var ret error
-	offset := map[string]map[int32]kgo.EpochOffset{}
-	offset[this.qCfg.ID] = map[int32]kgo.EpochOffset{}
-	offset[this.qCfg.ID][0] = kgo.EpochOffset{Offset: off.Position, Epoch: -1}
-	this.client.CommitOffsetsSync(ctx, offset, func(client *kgo.Client, request *kmsg.OffsetCommitRequest, response *kmsg.OffsetCommitResponse, err error) {
+	this.client.CommitOffsetsSync(ctx, offsetsToCommit(this.qCfg, off), func(client *kgo.Client, request *kmsg.OffsetCommitRequest, response *kmsg.OffsetCommitResponse, err error) {
 		if ret != nil {
 			log.Error(ret)
 		}
@@ -87,6 +84,19 @@ func (this *Consumer) CommitOffset(off queue.Offset) error {
 		log.Infof("commit %v[%v] offset: %v", this.qCfg.Name, this.qCfg.ID, off.String())
 	}
 	return ret
+}
+
+// offsetsToCommit builds the kgo commit request for one queue offset. The
+// partition comes from the offset itself (queue offsets carry
+// segment=partition since FetchMessages): committing hard-wired to
+// partition 0 silently corrupted the committed positions of every
+// multi-partition topic — each partition's progress overwrote partition 0's
+// commit and its own was never persisted.
+func offsetsToCommit(qCfg *queue.QueueConfig, off queue.Offset) map[string]map[int32]kgo.EpochOffset {
+	offset := map[string]map[int32]kgo.EpochOffset{}
+	offset[qCfg.ID] = map[int32]kgo.EpochOffset{}
+	offset[qCfg.ID][int32(off.Segment)] = kgo.EpochOffset{Offset: off.Position, Epoch: -1}
+	return offset
 }
 
 func (this *Consumer) FetchMessages(ctx *queue.Context, numOfMessages int) (messages []queue.Message, isTimeout bool, err error) {

--- a/plugins/queue/kafka_queue/offsets_commit_test.go
+++ b/plugins/queue/kafka_queue/offsets_commit_test.go
@@ -1,0 +1,37 @@
+package kafka_queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"infini.sh/framework/core/queue"
+)
+
+// CommitOffset historically committed every offset to partition 0
+// (hard-wired map index), corrupting multi-partition topics: each
+// partition's progress overwrote partition 0's commit and its own position
+// was never persisted. The partition must come from the offset's segment —
+// exactly what FetchMessages stores there (NewOffset(r.Partition, r.Offset)).
+func TestOffsetsToCommit_UsesOffsetPartition(t *testing.T) {
+	qCfg := &queue.QueueConfig{ID: "test-topic", Name: "test-topic"}
+
+	for partition := int64(0); partition < 5; partition++ {
+		off := queue.NewOffset(partition, 100+partition)
+		m := offsetsToCommit(qCfg, off)
+
+		inner, ok := m["test-topic"]
+		assert.True(t, ok, "topic map must exist")
+		assert.Len(t, inner, 1, "exactly one partition entry (partition %d)", partition)
+
+		eo, ok := inner[int32(partition)]
+		assert.True(t, ok, "entry must be keyed by the offset's own partition %d", partition)
+		assert.Equal(t, int64(100+partition), eo.Offset)
+		assert.Equal(t, int32(-1), eo.Epoch)
+
+		// no other partition — in particular 0 — may receive this commit
+		for p := range inner {
+			assert.Equal(t, int32(partition), p, "commit leaked to partition %d", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Three defects from the kafka consumption audit (queue selection, offset commits, per-processor consumer config):

1. **`GetConfigByLabels` matched ANY single label pair instead of ALL requested pairs** — a queue tagged `{topic:x}` was selected by a `{topic:x, env:prod}` selector. Now strict AND: a missing key or a different value excludes the queue.

2. **kafka `CommitOffset` committed every offset to partition 0** (hard-wired map index). On multi-partition topics each partition's progress overwrote partition 0's commit and its own position was never persisted — after a restart consumers reprocessed or skipped data. The partition now comes from the offset's segment, exactly where `FetchMessages` stores it (`NewOffset(r.Partition, r.Offset)`).

3. **The queue-consumer processor mutated the shared registry config** when applying its `consumer` overrides (two processors on the same queue+group clobbered each other's settings), and only six fields were covered: `eof_max_retry_times`, `client_expired_in_seconds` and `auto_reset_offset` were silently unconfigurable from the processor. Overrides now apply to a `Clone()` and cover every consumer field.

## Tests

- label AND/selector semantics: missing key, value mismatch, extra labels, string-form value comparison, empty selector, unlabeled queues
- override full-coverage / zero-value-keeps-base / clone-independence (registry object stays untouched, identity fields survive)
- kafka commit map keyed by the offset's own partition, no partition-0 leak
