### PR TITLE
fixdoc: relative page links instead of relref shortcodes in docs

### DIFF
--- a/docs/content.en/docs/references/_index.md
+++ b/docs/content.en/docs/references/_index.md
@@ -10,29 +10,30 @@ Comprehensive reference documentation for the INFINI Framework's core systems an
 
 ## Core Systems
 
-- [Configuration]({{< relref "config" >}}) — YAML configuration management, environment variables, keystore secrets, and config file watching
-- [Modules]({{< relref "modules" >}}) — Module lifecycle system for building and registering framework extensions
-- [Pipeline & Processors]({{< relref "pipeline" >}}) — Data processing pipelines with conditional logic and custom processor development
-- [Task Scheduling]({{< relref "task" >}}) — Interval-based, cron-based, and transient task execution
-- [Pipeline Record Processing]({{< relref "pipeline_record" >}}) — The record-processing convention: batch splitting, pluggable payload codecs, failure strategies, and batch-aware processors
-- [Queue]({{< relref "queue" >}}) — Pluggable message queue abstraction with disk, memory, Kafka, and Redis backends
-- [Key-Value Store]({{< relref "kv" >}}) — Pluggable KV storage with Badger, Elasticsearch, and file-based backends
-- [Statistics]({{< relref "stats" >}}) — Metrics collection with counters, gauges, timings, and StatsD integration
-- [Conditions]({{< relref "conditions" >}}) — Declarative condition evaluation with logical operators for pipeline control flow
+- [Configuration](config/) — YAML configuration management, environment variables, keystore secrets, and config file watching
+- [Modules](modules/) — Module lifecycle system for building and registering framework extensions
+- [Pipeline & Processors](pipeline/) — Data processing pipelines with conditional logic and custom processor development
+- [Processor Reference](processors/) — One reference page per registered processor: configuration parameters, defaults, and examples
+- [Task Scheduling](task/) — Interval-based, cron-based, and transient task execution
+- [Pipeline Record Processing](pipeline_record/) — The record-processing convention: batch splitting, pluggable payload codecs, failure strategies, and batch-aware processors
+- [Queue](queue/) — Pluggable message queue abstraction with disk, memory, Kafka, and Redis backends
+- [Key-Value Store](kv/) — Pluggable KV storage with Badger, Elasticsearch, and file-based backends
+- [Statistics](stats/) — Metrics collection with counters, gauges, timings, and StatsD integration
+- [Conditions](conditions/) — Declarative condition evaluation with logical operators for pipeline control flow
 
 ## API & Data
 
-- [API & Web Framework]({{< relref "api_web" >}}) — HTTP API server, web server, routing, middleware, and security configuration
-- [Security & Authentication]({{< relref "security" >}}) — Authentication backends (static, native, OAuth, access tokens), unified `/account/login`, and role-based authorization
-- [MCP Server]({{< relref "mcp" >}}) — Model Context Protocol server support — expose APIs as AI-callable tools via `api.MCPTool()`
-- [ORM]({{< relref "orm" >}}) — Object-Relational Mapping for Elasticsearch with CRUD operations and query building
-- [Query URL Parameters]({{< relref "query_url" >}}) — URL-based query parameters for full-text search and structured filters
-- [Aggregation Queries]({{< relref "aggs_query" >}}) — Dynamic aggregation construction via URL query parameters
+- [API & Web Framework](api_web/) — HTTP API server, web server, routing, middleware, and security configuration
+- [Security & Authentication](security/) — Authentication backends (static, native, OAuth, access tokens), unified `/account/login`, and role-based authorization
+- [MCP Server](mcp/) — Model Context Protocol server support — expose APIs as AI-callable tools via `api.MCPTool()`
+- [ORM](orm/) — Object-Relational Mapping for Elasticsearch with CRUD operations and query building
+- [Query URL Parameters](query_url/) — URL-based query parameters for full-text search and structured filters
+- [Aggregation Queries](aggs_query/) — Dynamic aggregation construction via URL query parameters
 
 ## Operations
 
-- [HTTP Client]({{< relref "http_client" >}}) — HTTP client configuration with proxy, TLS, and connection management
-- [Reverse Websocket Channel]({{< relref "websocket_reverse" >}}) — Control-plane-to-agent HTTP proxying over agent-initiated websockets (NAT traversal without inbound ports)
-- [Service Management]({{< relref "service" >}}) — Install, start, stop, and uninstall services, including run-as-user setup
-- [Keystore]({{< relref "keystore" >}}) — Secure storage for sensitive configuration values
-- [Makefile]({{< relref "makefile" >}}) — Build system commands and variables
+- [HTTP Client](http_client/) — HTTP client configuration with proxy, TLS, and connection management
+- [Reverse Websocket Channel](websocket_reverse/) — Control-plane-to-agent HTTP proxying over agent-initiated websockets (NAT traversal without inbound ports)
+- [Service Management](service/) — Install, start, stop, and uninstall services, including run-as-user setup
+- [Keystore](keystore/) — Secure storage for sensitive configuration values
+- [Makefile](makefile/) — Build system commands and variables

--- a/docs/content.en/docs/references/config.md
+++ b/docs/content.en/docs/references/config.md
@@ -242,7 +242,7 @@ elasticsearch:
       password: $[[keystore.es_password]]
 ```
 
-Secrets are managed with the `keystore` CLI subcommand (see [Keystore]({{< relref "keystore" >}}) for details). At load time, `$[[keystore.es_password]]` is replaced with the decrypted value of the `es_password` key from the keystore.
+Secrets are managed with the `keystore` CLI subcommand (see [Keystore](keystore/) for details). At load time, `$[[keystore.es_password]]` is replaced with the decrypted value of the `es_password` key from the keystore.
 
 Keystore references and environment variables can be used together in the same configuration file. Keystore references are resolved separately from environment variable interpolation.
 

--- a/docs/content.en/docs/references/security.md
+++ b/docs/content.en/docs/references/security.md
@@ -102,7 +102,7 @@ users:
     roles: [admin]
 ```
 
-See [Keystore]({{< relref "keystore" >}}) for managing secret values.
+See [Keystore](keystore/) for managing secret values.
 
 ### Other backends
 
@@ -203,7 +203,7 @@ A permission key is an opaque string the application defines and checks via
 `api.RequirePermission(...)`. Conventions vary by app — e.g.
 `"<scope>:<resource>:<action>"` or `"<scope>#<resource>/<action>"`. The
 framework itself only compares strings; the application registers the
-meaningful keys (see [API & Web Framework]({{< relref "api_web" >}}) for how
+meaningful keys (see [API & Web Framework](api_web/) for how
 handlers attach permission requirements).
 
 ---

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -53,6 +53,7 @@ Information about release notes of INFINI Framework is provided here.
 - refactor: rate limit the large cluster warning in metric collection #394
 - docs: catalog built-in processors and condition operators in the pipeline/conditions references #414
 - docs: per-processor and per-condition reference sections — one page for each of the 51 registered processors and 16 condition operators, in a uniform format (category/scope, configuration parameters with types and defaults, examples) #414
+- fixdoc: replace relref shortcodes embedded in link destinations with plain relative page links, silencing the docs build's "Page 'HAHAHUGOSHORTCODE-...' not found" warnings #415
 
 ## 1.4.2 (2026-06-23)
 ### ❌ Breaking changes  


### PR DESCRIPTION
## Problem

The docs build emits warnings like:

```
WARN Page 'HAHAHUGOSHORTCODE-s0-HBHB' not found in 'docs/references/_index.md'
WARN Page 'HAHAHUGOSHORTCODE-s1-HBHB' not found in 'docs/references/config.md'
...
```

## Root Cause

Hugo's markdown renderer substitutes shortcodes embedded in link destinations with `HAHAHUGOSHORTCODE-sN-HBHB` placeholders before resolving the link as a page reference, so every `[label]({{< relref "page" >}})` triggers a "Page not found" warning for the placeholder (the rendered output still resolves — it is noise, but 20+ lines of it per build).

23 occurrences across `references/_index.md` (20), `references/config.md` (1) and `references/security.md` (2).

## Fix

Replaced all of them with plain relative page links (`[label](page/)`), which resolve to the same pages without the placeholder round-trip. The references index also gained an entry for the new Processor Reference section, and the Conditions entry now points at the conditions section introduced by #414.
