### PR TITLE
feat(configs): token helpers, queue purge API, reverse-channel compression, instance log tail API

### DIFF
--- a/core/api/websocket/reverse/manager.go
+++ b/core/api/websocket/reverse/manager.go
@@ -33,12 +33,15 @@ type ManagerOptions struct {
 }
 
 type pendingResponse struct {
-	peerID    string
-	body      bytes.Buffer
-	status    int
-	err       error
-	done      chan struct{}
-	completed bool
+	peerID string
+	body   bytes.Buffer
+	// compressed marks the assembled body as gzip-encoded (flag comes from
+	// the peer's chunk frames); inflated before the response is delivered.
+	compressed bool
+	status     int
+	err        error
+	done       chan struct{}
+	completed  bool
 }
 
 type SessionManager struct {
@@ -97,12 +100,17 @@ func (m *SessionManager) ActivateSession(sessionID, peerID string) error {
 	return nil
 }
 
-func (m *SessionManager) HandleHelloPayload(payload string) error {
+// HandleHelloPayload activates the session and returns the features the
+// peer advertised, so the caller can answer with its own capabilities.
+func (m *SessionManager) HandleHelloPayload(payload string) ([]string, error) {
 	msg, err := ParseHelloPayload(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return m.ActivateSession(msg.SessionID, msg.PeerID)
+	if err := m.ActivateSession(msg.SessionID, msg.PeerID); err != nil {
+		return nil, err
+	}
+	return msg.Features, nil
 }
 
 func (m *SessionManager) HandleResponsePayload(payload string) error {
@@ -275,9 +283,14 @@ func (m *SessionManager) acceptResponse(msg ResponseMessage) {
 			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("decode reverse response chunk: %w", err))
 			return
 		}
+		// the cap applies to the wire size (compressed bytes), so large
+		// compressible payloads stay well under it in transit
 		if pending.body.Len()+len(chunk) > m.options.MaxResponseBytes {
 			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("reverse response exceeds %d bytes", m.options.MaxResponseBytes))
 			return
+		}
+		if msg.Compressed {
+			pending.compressed = true
 		}
 		_, _ = pending.body.Write(chunk)
 	}
@@ -290,6 +303,15 @@ func (m *SessionManager) acceptResponse(msg ResponseMessage) {
 		if msg.Status == 0 {
 			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("malformed reverse response: done frame carries neither status nor error"))
 			return
+		}
+		if pending.compressed {
+			inflated, err := MaybeDecompress(pending.body.Bytes(), true)
+			if err != nil {
+				m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("reverse response inflate: %w", err))
+				return
+			}
+			pending.body.Reset()
+			_, _ = pending.body.Write(inflated)
 		}
 		m.completePendingLocked(msg.RequestID, pending, msg.Status, nil)
 	}

--- a/core/api/websocket/reverse/protocol.go
+++ b/core/api/websocket/reverse/protocol.go
@@ -1,8 +1,11 @@
 package reverse
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -14,12 +17,38 @@ const (
 	HelloCommand              = "reverse_hello"
 	RequestCommand            = "reverse_request"
 	ResponseCommand           = "reverse_response"
+	FeaturesCommand           = "reverse_features"
 	DefaultResponseChunkBytes = 32 * 1024
+	// CompressThresholdBytes — response bodies below this stay uncompressed:
+	// gzip overhead (~60+ bytes) isn't worth it for small payloads.
+	CompressThresholdBytes = 4 * 1024
+	// CompressionGzip is the only wire format advertised today.
+	CompressionGzip = "gzip"
 )
 
 type HelloMessage struct {
 	SessionID string `json:"session_id"`
 	PeerID    string `json:"instance_id"`
+	// Features advertises peer capabilities, e.g. ["gzip"]. The manager
+	// answers with a reverse_features frame so both sides compress only
+	// when the other end actually supports it (mixed-version safe).
+	Features []string `json:"features,omitempty"`
+}
+
+// FeatureMessage is the manager's capability answer to a HELLO that
+// advertised features.
+type FeatureMessage struct {
+	Gzip bool `json:"gzip"`
+}
+
+// SupportsCompression reports whether the peer advertised gzip support.
+func (m HelloMessage) SupportsCompression() bool {
+	for _, f := range m.Features {
+		if f == CompressionGzip {
+			return true
+		}
+	}
+	return false
 }
 
 type RequestMessage struct {
@@ -36,6 +65,10 @@ type ResponseMessage struct {
 	RequestID string `json:"request_id"`
 	PeerID    string `json:"instance_id"`
 	Chunk     string `json:"chunk,omitempty"`
+	// Compressed marks the reassembled body as gzip-encoded. Set on every
+	// chunk frame of a compressed response so the manager knows to inflate
+	// before handing the body to the caller.
+	Compressed bool `json:"compressed,omitempty"`
 	// Status is the HTTP status of the locally executed request, set on the
 	// Done frame. 0 is not a valid HTTP status (valid range is 100-599);
 	// a Done frame without Status is only legal together with Error.
@@ -64,6 +97,53 @@ func ParseResponsePayload(payload string) (ResponseMessage, error) {
 
 func FormatHelloCommand(msg HelloMessage) string {
 	return HelloCommand + " " + string(util.MustToJSONBytes(msg))
+}
+
+func FormatFeatureCommand(msg FeatureMessage) string {
+	return FeaturesCommand + " " + string(util.MustToJSONBytes(msg))
+}
+
+func ParseFeaturePayload(payload string) (FeatureMessage, error) {
+	msg := FeatureMessage{}
+	return msg, util.FromJSONBytes([]byte(payload), &msg)
+}
+
+// MaybeCompress gzips body when it is worth it (size threshold, and only
+// when compression actually shrinks it). Returns the (possibly unchanged)
+// body and whether it was compressed.
+func MaybeCompress(body []byte) ([]byte, bool) {
+	if len(body) < CompressThresholdBytes {
+		return body, false
+	}
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(body); err != nil {
+		return body, false
+	}
+	if err := w.Close(); err != nil {
+		return body, false
+	}
+	if buf.Len() >= len(body) {
+		return body, false // incompressible
+	}
+	return buf.Bytes(), true
+}
+
+// MaybeDecompress inflates body when compressed is true.
+func MaybeDecompress(body []byte, compressed bool) ([]byte, error) {
+	if !compressed {
+		return body, nil
+	}
+	r, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer r.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("gzip inflate: %w", err)
+	}
+	return out, nil
 }
 
 func FormatRequestCommand(msg RequestMessage) string {

--- a/core/api/websocket/reverse/protocol_test.go
+++ b/core/api/websocket/reverse/protocol_test.go
@@ -83,3 +83,43 @@ func TestWriteFailureResponse(t *testing.T) {
 		t.Fatalf("unexpected failure frame: %+v", msg)
 	}
 }
+
+func TestCompressionRoundTrip(t *testing.T) {
+	body := []byte(strings.Repeat(`{"message":"hello world","level":"info"}`, 500))
+	if len(body) < CompressThresholdBytes {
+		t.Fatalf("test body too small: %v", len(body))
+	}
+	compressed, ok := MaybeCompress(body)
+	if !ok {
+		t.Fatal("expected body to be compressed")
+	}
+	if len(compressed) >= len(body) {
+		t.Fatal("compressed body should be smaller")
+	}
+	back, err := MaybeDecompress(compressed, true)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if string(back) != string(body) {
+		t.Fatal("round trip mismatch")
+	}
+	// small bodies stay uncompressed
+	small := []byte(`{"a":1}`)
+	if out, ok := MaybeCompress(small); ok {
+		t.Fatalf("small body should not be compressed, got %v bytes", len(out))
+	}
+}
+
+func TestResponseMessageCompressedFlag(t *testing.T) {
+	msg := ResponseMessage{RequestID: "r1", Compressed: true}
+	wire := FormatResponseCommand(msg)
+	// wire is "<command> <json>"
+	payloadIdx := strings.Index(wire, "{")
+	m2, err := ParseResponsePayload(wire[payloadIdx:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m2.Compressed {
+		t.Fatal("compressed flag lost on wire round trip")
+	}
+}

--- a/core/model/instance.go
+++ b/core/model/instance.go
@@ -63,7 +63,7 @@ type Instance struct {
 	// "gateway-edge"): managed from the management UI, used to target
 	// config delivery (ManagedConfig.Groups). Instances do not report it —
 	// registration/heartbeat upserts preserve the stored value.
-	Groups []string `json:"groups,omitempty" elastic_mapping:"groups:{type:keyword}}"`
+	Groups []string `json:"groups,omitempty" elastic_mapping:"groups:{type:keyword}"`
 
 	//user can pass
 	Description string `json:"description,omitempty" config:"description" elastic_mapping:"description:{type:keyword}"`

--- a/core/queue/api.go
+++ b/core/queue/api.go
@@ -82,6 +82,29 @@ type ConsumerAPI interface {
 	CommitOffset(offset Offset) error
 }
 
+// QueuePurgeAPI is an optional handler capability: drop all buffered
+// messages and already-consumed segment files without destroying the queue
+// registration itself. Handlers without purge support (e.g. kafka) simply
+// don't implement it.
+type QueuePurgeAPI interface {
+	Empty(k string) error
+}
+
+// EmptyQueue purges every message of a queue through its handler's purge
+// support. Consumers and offsets are kept: disk-queue consumers resume from
+// the fresh head (out-of-range offsets auto-reset).
+// NOTE: keyed by k.ID — the handlers' storage and instance maps are ID-keyed.
+func EmptyQueue(k *QueueConfig) error {
+	if k == nil || k.ID == "" {
+		return errors.New("invalid queue config")
+	}
+	handler := GetHandlerByType(k.Type)
+	if h, ok := handler.(QueuePurgeAPI); ok {
+		return h.Empty(k.ID)
+	}
+	return errors.Errorf("queue type [%v] does not support purging", k.Type)
+}
+
 var defaultHandler QueueAPI
 
 func getSimpleHandler(k *QueueConfig) SimpleQueueAPI {

--- a/core/util/saferead.go
+++ b/core/util/saferead.go
@@ -75,8 +75,10 @@ func isSystemReadCanonical(c string) bool {
 	if c == "/" || c == string(filepath.Separator) {
 		return true
 	}
-	// drive-qualified path (Windows): compare the volume-relative part
-	if len(c) > 1 && c[1] == ':' {
+	// drive-qualified path (Windows): compare the volume-relative part.
+	// The separator check keeps unix paths whose second character happens
+	// to be ':' (e.g. /t:mp) on the unix branch.
+	if len(c) > 2 && c[1] == ':' && (c[2] == '/' || c[2] == '\\') {
 		c = filepath.ToSlash(c)
 		if len(c) <= 3 { // bare drive root, e.g. C:/
 			return true
@@ -156,7 +158,7 @@ func (g *ReadGuard) Roots() []string {
 }
 
 // Contains reports whether path canonicalizes to exactly one of the
-// allowed roots — the check for caller-supplied base directories.
+// allowed roots.
 func (g *ReadGuard) Contains(path string) bool {
 	if strings.TrimSpace(path) == "" {
 		return false
@@ -170,17 +172,36 @@ func (g *ReadGuard) Contains(path string) bool {
 	return false
 }
 
-// ResolveUnder resolves file against base (which must be one of the
-// allowed roots) and returns its canonical path when it lands strictly
+// ContainsUnder reports whether path canonicalizes to one of the allowed
+// roots or to a location strictly below one of them — the check for
+// caller-supplied base directories that may be a subdirectory of a
+// whitelisted root (e.g. a GC log dir configured under path.logs).
+func (g *ReadGuard) ContainsUnder(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	c := canonicalReadPath(path)
+	for _, r := range g.roots {
+		if c == r || strings.HasPrefix(c, r+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveUnder resolves file against base (which must be an allowed root
+// or live below one) and returns its canonical path when it lands strictly
 // below an allowed root, outside every system tree, and is an existing
 // regular file (so devices, fifos and sockets can never be served).
 // file may be relative (joined to base) or absolute (accepted only when
-// it still resolves inside the roots).
+// it still resolves inside the roots); the roots — not base — remain the
+// trust boundary, so a file name escaping base but staying inside the
+// root is still served.
 func (g *ReadGuard) ResolveUnder(base, file string) (string, error) {
 	if strings.TrimSpace(file) == "" {
 		return "", fmt.Errorf("file is required")
 	}
-	if !g.Contains(base) {
+	if !g.ContainsUnder(base) {
 		return "", fmt.Errorf("path [%v] is not an allowed directory", base)
 	}
 	target := file

--- a/core/util/saferead.go
+++ b/core/util/saferead.go
@@ -1,0 +1,212 @@
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Read-side file access control: any handler that serves file contents
+// driven by external input (a caller-supplied directory, a file name from
+// a query string) must resolve the path through a ReadGuard so the
+// endpoint cannot be turned into a general-purpose file reader.
+//
+// Two layers, deny always wins:
+//  1. IsSystemReadPath — OS-critical trees are never readable, even when
+//     a whitelist root was misconfigured to include them.
+//  2. ReadGuard — files must live strictly below one of the explicitly
+//     allowed roots (symlink-resolved on both sides).
+
+// systemReadPrefixes lists trees that never legitimately hold readable
+// service logs, so serving reads from them is refused outright. It is
+// deliberately narrower than safedelete's neverTouch: packaged products
+// keep logs under /usr/share/<product>/logs (RPM/DEB installs) and
+// /var/log, /opt, /home are standard log locations — those stay
+// reachable, constrained by the whitelist instead.
+var systemReadPrefixes = []string{
+	"/bin", "/sbin", "/boot", "/dev", "/etc", "/proc", "/sys", "/run",
+	"/lib", "/lib64", "/libx32", "/root", "/kernel",
+	"/System", "/private/etc",
+	"/usr/bin", "/usr/sbin", "/usr/lib", "/usr/lib64", "/usr/libx32",
+}
+
+// windowsSystemReadPrefixes are matched against the volume-relative part
+// of a drive path (C:/Windows/... -> /Windows/...) case-insensitively.
+var windowsSystemReadPrefixes = []string{
+	"/Windows", "/Program Files/WindowsApps",
+}
+
+// tooBroadReadRoots lists top-level trees that hold far more than logs;
+// whitelisting one of them verbatim (instead of a specific subdirectory)
+// is treated as a misconfiguration and rejected. Their contents remain
+// reachable through narrower roots.
+var tooBroadReadRoots = []string{
+	"/usr", "/var", "/opt", "/srv", "/home", "/mnt", "/media", "/tmp",
+	"/private/var", "/private/tmp",
+}
+
+// IsSystemReadPath reports whether p is an OS-critical location that must
+// never be served by a file-reading API: the filesystem root, a
+// systemReadPrefixes member or anything under it (drive roots and the
+// listed Windows trees on Windows).
+func IsSystemReadPath(p string) bool {
+	return isSystemReadCanonical(canonicalReadPath(p))
+}
+
+// canonicalReadPath canonicalizes p and maps macOS firmlink paths
+// (/System/Volumes/Data/...) back to their firmlink view (/home, /opt,
+// ...) so every guard layer compares the same spelling.
+func canonicalReadPath(p string) string {
+	c := canonicalPath(p)
+	if strings.HasPrefix(c, "/System/Volumes/Data/") {
+		c = c[len("/System/Volumes/Data"):]
+	}
+	return c
+}
+
+// isSystemReadCanonical applies the deny checks to an already-canonical
+// path so the Windows rules stay testable on every platform.
+func isSystemReadCanonical(c string) bool {
+	if c == "/" || c == string(filepath.Separator) {
+		return true
+	}
+	// drive-qualified path (Windows): compare the volume-relative part
+	if len(c) > 1 && c[1] == ':' {
+		c = filepath.ToSlash(c)
+		if len(c) <= 3 { // bare drive root, e.g. C:/
+			return true
+		}
+		rel := strings.ToLower(c[2:]) // /windows/system32
+		for _, prefix := range windowsSystemReadPrefixes {
+			prefix = strings.ToLower(prefix)
+			if rel == prefix || strings.HasPrefix(rel, prefix+"/") {
+				return true
+			}
+		}
+		return false
+	}
+	for _, prefix := range systemReadPrefixes {
+		if c == prefix || strings.HasPrefix(c, prefix+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isTooBroadReadRoot reports whether an already-canonical directory is a
+// wholesale top-level tree rather than a specific log location.
+func isTooBroadReadRoot(c string) bool {
+	for _, broad := range tooBroadReadRoots {
+		if c == broad {
+			return true
+		}
+	}
+	return false
+}
+
+// ReadGuard confines file reads to a fixed set of allowed roots. Roots
+// are canonicalized (absolute + symlink-resolved) once at construction;
+// every later ResolveUnder call re-resolves the target the same way so a
+// symlink cannot smuggle a path outside the roots.
+type ReadGuard struct {
+	roots []string
+}
+
+// NewReadGuard validates and canonicalizes the allowed roots. Every root
+// must exist, be a directory, be a specific-enough location (not a
+// wholesale /usr or /var), and not be a system path — a bad root fails
+// loudly instead of being silently dropped.
+func NewReadGuard(roots ...string) (*ReadGuard, error) {
+	g := &ReadGuard{}
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		c := canonicalReadPath(root)
+		if IsSystemReadPath(c) {
+			return nil, fmt.Errorf("refusing to serve reads from system path: %s", c)
+		}
+		if isTooBroadReadRoot(c) {
+			return nil, fmt.Errorf("allowed path %s is too broad, whitelist a specific log directory instead", c)
+		}
+		fi, err := os.Stat(c)
+		if err != nil {
+			return nil, fmt.Errorf("allowed path %s is not accessible: %v", c, err)
+		}
+		if !fi.IsDir() {
+			return nil, fmt.Errorf("allowed path %s is not a directory", c)
+		}
+		g.roots = append(g.roots, c)
+	}
+	if len(g.roots) == 0 {
+		return nil, fmt.Errorf("no allowed read paths configured")
+	}
+	return g, nil
+}
+
+// Roots returns the canonical allowed roots.
+func (g *ReadGuard) Roots() []string {
+	return append([]string(nil), g.roots...)
+}
+
+// Contains reports whether path canonicalizes to exactly one of the
+// allowed roots — the check for caller-supplied base directories.
+func (g *ReadGuard) Contains(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	c := canonicalReadPath(path)
+	for _, r := range g.roots {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveUnder resolves file against base (which must be one of the
+// allowed roots) and returns its canonical path when it lands strictly
+// below an allowed root, outside every system tree, and is an existing
+// regular file (so devices, fifos and sockets can never be served).
+// file may be relative (joined to base) or absolute (accepted only when
+// it still resolves inside the roots).
+func (g *ReadGuard) ResolveUnder(base, file string) (string, error) {
+	if strings.TrimSpace(file) == "" {
+		return "", fmt.Errorf("file is required")
+	}
+	if !g.Contains(base) {
+		return "", fmt.Errorf("path [%v] is not an allowed directory", base)
+	}
+	target := file
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(canonicalReadPath(base), target)
+	}
+	c := canonicalReadPath(target)
+	if IsSystemReadPath(c) {
+		return "", fmt.Errorf("path [%v] is a system path", file)
+	}
+	contained := false
+	for _, r := range g.roots {
+		if strings.HasPrefix(c, r+string(filepath.Separator)) {
+			contained = true
+			break
+		}
+	}
+	if !contained {
+		return "", fmt.Errorf("file [%v] is outside of the allowed directories", file)
+	}
+	fi, err := os.Stat(c)
+	if err != nil {
+		return "", fmt.Errorf("cannot access file [%v]: %v", file, err)
+	}
+	if !fi.Mode().IsRegular() {
+		return "", fmt.Errorf("[%v] is not a regular file", file)
+	}
+	return c, nil
+}

--- a/core/util/saferead_test.go
+++ b/core/util/saferead_test.go
@@ -43,6 +43,17 @@ func TestIsSystemReadPath(t *testing.T) {
 	}
 }
 
+func TestIsSystemReadPathUnixPathWithColon(t *testing.T) {
+	// second-char-colon unix paths must stay on the unix branch: not
+	// system paths themselves, and real system paths still denied
+	if IsSystemReadPath("/t:mp/logs/server.log") {
+		t.Error("expected colon-containing unix path to be readable")
+	}
+	if !IsSystemReadPath("/etc/passwd") {
+		t.Error("expected /etc/passwd to stay denied")
+	}
+}
+
 func TestIsSystemReadCanonicalWindows(t *testing.T) {
 	denied := []string{
 		"C:/Windows", "C:/Windows/System32/cmd.exe", "c:/windows/system32/x.dll",
@@ -156,6 +167,43 @@ func TestReadGuardRejectsNonRegularFiles(t *testing.T) {
 	}
 	if _, err := guard.ResolveUnder(dir, "pipe.log"); err == nil {
 		t.Error("expected fifo to be rejected")
+	}
+}
+
+func TestReadGuardContainsUnder(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "gc")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	guard, err := NewReadGuard(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !guard.ContainsUnder(dir) {
+		t.Error("expected root itself to match")
+	}
+	if !guard.ContainsUnder(sub) {
+		t.Error("expected subdirectory of the root to match")
+	}
+	if guard.ContainsUnder(dir + "-sibling") {
+		t.Error("expected prefix sibling to be rejected")
+	}
+	if guard.ContainsUnder("/etc") {
+		t.Error("expected outside path to be rejected")
+	}
+
+	// base may be a subdirectory; the root stays the trust boundary
+	logFile := filepath.Join(dir, "server.log")
+	if err := os.WriteFile(logFile, []byte("line"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := guard.ResolveUnder(sub, "../server.log"); err != nil || got != canonicalPath(logFile) {
+		t.Errorf("expected escape from base but not root to resolve, got %v %v", got, err)
+	}
+	if _, err := guard.ResolveUnder(sub, "../../../etc/passwd"); err == nil {
+		t.Error("expected escape out of the root to be rejected")
 	}
 }
 

--- a/core/util/saferead_test.go
+++ b/core/util/saferead_test.go
@@ -1,0 +1,228 @@
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsSystemReadPath(t *testing.T) {
+	denied := []string{
+		"/",
+		"/etc", "/etc/passwd", "/etc/ssl/private/server.key",
+		"/bin/ls", "/sbin", "/boot/grub",
+		"/usr/bin/ls", "/usr/sbin/x", "/usr/lib/x.so", "/usr/lib64/x.so",
+		"/root/.ssh/id_rsa", "/kernel",
+		"/System/Library", "/private/etc/hosts",
+		"/proc/self/environ", "/sys/kernel", "/dev/sda", "/run/secrets/token",
+		// traversal into a system tree
+		"/var/log/../../../etc/passwd",
+	}
+	for _, p := range denied {
+		if !IsSystemReadPath(p) {
+			t.Errorf("expected [%s] to be a system read path", p)
+		}
+	}
+
+	allowed := []string{
+		"/var/log/elasticsearch",
+		"/usr/share/easysearch/logs/server.log",
+		"/opt/myapp/logs",
+		"/home/user/logs/app.log",
+		"/srv/service/logs",
+	}
+	for _, p := range allowed {
+		if IsSystemReadPath(p) {
+			t.Errorf("expected [%s] to be a readable location", p)
+		}
+	}
+}
+
+func TestIsSystemReadCanonicalWindows(t *testing.T) {
+	denied := []string{
+		"C:/Windows", "C:/Windows/System32/cmd.exe", "c:/windows/system32/x.dll",
+		"C:/Program Files/WindowsApps/App",
+	}
+	for _, p := range denied {
+		if !isSystemReadCanonical(p) {
+			t.Errorf("expected [%s] to be a system read path", p)
+		}
+	}
+	allowed := []string{
+		"C:/Program Files/Elasticsearch/logs",
+		"C:/elastic/logs/server.log",
+		"C:/ProgramData/myapp/logs",
+	}
+	for _, p := range allowed {
+		if isSystemReadCanonical(p) {
+			t.Errorf("expected [%s] to be a readable location", p)
+		}
+	}
+}
+
+func TestNewReadGuardRootValidation(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := NewReadGuard(dir); err != nil {
+		t.Fatalf("expected temp dir to be a valid root: %v", err)
+	}
+
+	for _, bad := range []string{"/etc", "/usr/bin", "/root", "/"} {
+		if _, err := NewReadGuard(bad); err == nil {
+			t.Errorf("expected system path [%s] to be rejected as root", bad)
+		}
+	}
+	for _, broad := range []string{"/usr", "/var", "/opt", "/home", "/tmp"} {
+		if _, err := NewReadGuard(broad); err == nil {
+			t.Errorf("expected broad root [%s] to be rejected", broad)
+		}
+	}
+
+	file := filepath.Join(dir, "notadir.log")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewReadGuard(file); err == nil {
+		t.Error("expected non-directory root to be rejected")
+	}
+	missing := filepath.Join(dir, "does-not-exist")
+	if _, err := NewReadGuard(missing); err == nil {
+		t.Error("expected missing root to be rejected")
+	}
+	if _, err := NewReadGuard(); err == nil {
+		t.Error("expected empty roots to be rejected")
+	}
+}
+
+func TestReadGuardResolveUnder(t *testing.T) {
+	dir := t.TempDir()
+	guard, err := NewReadGuard(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logFile := canonicalPath(filepath.Join(dir, "server.log"))
+	if err := os.WriteFile(logFile, []byte("line"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := guard.ResolveUnder(dir, "server.log"); err != nil || got != logFile {
+		t.Errorf("relative resolve failed: %v %v", got, err)
+	}
+	if got, err := guard.ResolveUnder(dir, logFile); err != nil || got != logFile {
+		t.Errorf("absolute-inside resolve failed: %v %v", got, err)
+	}
+
+	for _, bad := range []string{
+		"../../../etc/passwd",
+		"/etc/passwd",
+		"",
+		".",
+		"missing.log",
+	} {
+		if _, err := guard.ResolveUnder(dir, bad); err == nil {
+			t.Errorf("expected file [%q] to be rejected", bad)
+		}
+	}
+
+	if _, err := guard.ResolveUnder("/etc", "passwd"); err == nil {
+		t.Error("expected base outside the roots to be rejected")
+	}
+}
+
+func TestReadGuardRejectsNonRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	guard, err := NewReadGuard(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sub := filepath.Join(dir, "nested")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guard.ResolveUnder(dir, "nested"); err == nil {
+		t.Error("expected directory passed as file to be rejected")
+	}
+
+	fifo := filepath.Join(dir, "pipe.log")
+	if err := mkFifo(fifo); err != nil {
+		t.Skipf("cannot create fifo on this platform: %v", err)
+	}
+	if _, err := guard.ResolveUnder(dir, "pipe.log"); err == nil {
+		t.Error("expected fifo to be rejected")
+	}
+}
+
+func TestReadGuardSymlinkEscape(t *testing.T) {
+	dir := t.TempDir()
+	guard, err := NewReadGuard(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logFile := canonicalPath(filepath.Join(dir, "server.log"))
+	if err := os.WriteFile(logFile, []byte("line"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(dir, "etc-link")
+	if err := os.Symlink("/etc", link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guard.ResolveUnder(dir, "etc-link/passwd"); err == nil {
+		t.Error("expected symlink escape into /etc to be rejected")
+	}
+
+	// a root reached through its own symlink still canonicalizes to itself
+	linkToRoot := dir + "-via-link"
+	if err := os.Symlink(dir, linkToRoot); err != nil {
+		t.Fatal(err)
+	}
+	if !guard.Contains(linkToRoot) {
+		t.Error("expected symlinked root variant to be recognized")
+	}
+	if got, err := guard.ResolveUnder(linkToRoot, "server.log"); err != nil || got != logFile {
+		t.Errorf("resolve via symlinked root failed: %v %v", got, err)
+	}
+}
+
+func TestReadGuardPrefixSafety(t *testing.T) {
+	base := t.TempDir()
+	sibling, err := os.MkdirTemp(filepath.Dir(base), filepath.Base(base)+"-sibling")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(sibling)
+	if strings.HasPrefix(sibling, base+string(filepath.Separator)) {
+		t.Fatalf("test requires sibling outside base: %s vs %s", sibling, base)
+	}
+
+	guard, err := NewReadGuard(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	escape := filepath.Join(sibling, "secret.log")
+	if err := os.WriteFile(escape, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guard.ResolveUnder(base, escape); err == nil {
+		t.Error("expected prefix-sibling path (base vs base-sibling) to be rejected")
+	}
+}
+
+func TestIsTooBroadReadRoot(t *testing.T) {
+	for _, broad := range []string{"/usr", "/var", "/private/var"} {
+		if !isTooBroadReadRoot(broad) {
+			t.Errorf("expected [%s] to be too broad", broad)
+		}
+	}
+	if isTooBroadReadRoot("/var/log/myapp") {
+		t.Error("expected specific subdir to be acceptable")
+	}
+}

--- a/core/util/saferead_test_unix.go
+++ b/core/util/saferead_test_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package util
+
+import "syscall"
+
+func mkFifo(path string) error {
+	return syscall.Mkfifo(path, 0600)
+}

--- a/core/util/saferead_test_windows.go
+++ b/core/util/saferead_test_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package util
+
+import "errors"
+
+func mkFifo(path string) error {
+	return errors.New("fifo is not supported on windows")
+}

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -95,21 +95,28 @@ func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.
 		api.DefaultAPI.WriteError(w, err.Error(), 500)
 		return
 	}
+	if util.IsSystemReadPath(logDir) {
+		api.DefaultAPI.WriteError(w, fmt.Sprintf("log dir [%v] is a system path", logDir), 500)
+		return
+	}
 
 	files := []logFileInfo{}
-	depth := 0
 	_ = filepath.Walk(logDir, func(p string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
 		if fi.IsDir() {
-			depth++
-			if depth > logReadDirMaxDepth {
+			if p == logDir {
+				return nil
+			}
+			// depth is derived from the relative path so sibling
+			// directories are not pruned by an earlier deep subtree
+			if rel, err := filepath.Rel(logDir, p); err == nil &&
+				strings.Count(rel, string(filepath.Separator))+1 > logReadDirMaxDepth {
 				return filepath.SkipDir
 			}
 			return nil
 		}
-		depth = 0
 		if !fi.Mode().IsRegular() {
 			return nil
 		}

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -11,7 +11,12 @@ package config
 //	GET /logging/files                     list log files (recursive, newest first)
 //	GET /logging/tail?file=&lines=&keyword=  tail a file, optional keyword filter
 //
-// Both are strictly read-only and confined to the configured log directory.
+// Both are strictly read-only. File access goes through util.ReadGuard with
+// the app's own log directory as the only allowed root: paths are
+// symlink-resolved and confined to that directory, system paths
+// (util.IsSystemReadPath) are denied outright, and only regular files are
+// served — the endpoints can never be turned into a general-purpose file
+// reader.
 
 import (
 	"fmt"
@@ -35,20 +40,22 @@ func init() {
 }
 
 const (
-	logTailMaxBytes   = 4 * 1024 * 1024 // scan at most the last 4MB of a file
-	logTailMaxLines   = 2000
+	logTailMaxBytes    = 4 * 1024 * 1024 // scan at most the last 4MB of a file
+	logTailMaxLines    = 2000
 	logReadDirMaxDepth = 6
 )
 
 type logFileInfo struct {
 	Name    string `json:"name"`
-	Path    string `json:"path"`    // relative to the log dir; pass back to /logging/tail
+	Path    string `json:"path"` // relative to the log dir; pass back to /logging/tail
 	Size    int64  `json:"size"`
 	Updated int64  `json:"updated"` // unix seconds
 	Current bool   `json:"current"` // most recently modified file
 }
 
-func logDirAbs() (string, error) {
+// currentLogDir resolves the directory the /logging endpoints serve;
+// overridable in tests.
+var currentLogDir = func() (string, error) {
 	dir := global.Env().GetLogDir()
 	if dir == "" {
 		return "", fmt.Errorf("log dir is not configured")
@@ -60,40 +67,30 @@ func logDirAbs() (string, error) {
 	return abs, nil
 }
 
-// resolveLogFile validates that file (relative to the log dir, or absolute)
-// resolves inside the log dir, and returns its absolute path.
+// resolveLogFile validates that file (relative to the log dir, or absolute
+// inside it) resolves to a regular file strictly inside the log directory,
+// and returns its absolute path.
 func resolveLogFile(file string) (string, error) {
-	logDir, err := logDirAbs()
+	logDir, err := currentLogDir()
 	if err != nil {
 		return "", err
 	}
-	if file == "" {
-		return "", fmt.Errorf("file is required")
-	}
-	target := file
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(logDir, file)
-	}
-	target, err = filepath.Abs(target)
+	guard, err := util.NewReadGuard(logDir)
 	if err != nil {
 		return "", err
 	}
-	// resolve symlinks on both sides to prevent escaping via links
-	if resolvedLogDir, err := filepath.EvalSymlinks(logDir); err == nil {
-		logDir = resolvedLogDir
-	}
-	resolved, err := filepath.EvalSymlinks(target)
-	if err != nil {
-		return "", err
-	}
-	if resolved != logDir && !strings.HasPrefix(resolved, logDir+string(filepath.Separator)) {
-		return "", fmt.Errorf("file [%v] is outside of the log directory", file)
-	}
-	return resolved, nil
+	return guard.ResolveUnder(logDir, file)
 }
 
 func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	logDir, err := logDirAbs()
+	logDir, err := currentLogDir()
+	if err != nil {
+		api.DefaultAPI.WriteError(w, err.Error(), 500)
+		return
+	}
+	// the walk below reports paths as given; make sure logDir itself is
+	// canonical so relative paths handed back to /logging/tail match
+	logDir, err = filepath.Abs(logDir)
 	if err != nil {
 		api.DefaultAPI.WriteError(w, err.Error(), 500)
 		return
@@ -113,6 +110,9 @@ func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.
 			return nil
 		}
 		depth = 0
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
 		if !strings.HasSuffix(fi.Name(), ".log") && !strings.HasSuffix(fi.Name(), ".json") {
 			return nil
 		}
@@ -220,12 +220,12 @@ func tailLogFileAction(w http.ResponseWriter, req *http.Request, ps httprouter.P
 	}
 
 	api.DefaultAPI.WriteJSON(w, util.MapStr{
-		"file":       fileParam,
-		"size":       fi.Size(),
-		"updated":    fi.ModTime().Unix(),
-		"keyword":    keyword,
-		"truncated":  fi.Size() > logTailMaxBytes,
-		"lines":      match,
+		"file":        fileParam,
+		"size":        fi.Size(),
+		"updated":     fi.ModTime().Unix(),
+		"keyword":     keyword,
+		"truncated":   fi.Size() > logTailMaxBytes,
+		"lines":       match,
 		"server_time": time.Now().Unix(),
 	}, 200)
 }

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -1,0 +1,240 @@
+/* ©INFINI, All Rights Reserved.
+ * mail: contact#infini.ltd */
+
+package config
+
+// Instance-local log viewing API, served by every framework app next to the
+// /config/ endpoints (embedded API on agents/gateways). Lets a managing
+// console (e.g. LogPilot) tail instance logs through its reverse channel for
+// pipeline troubleshooting:
+//
+//	GET /logging/files                     list log files (recursive, newest first)
+//	GET /logging/tail?file=&lines=&keyword=  tail a file, optional keyword filter
+//
+// Both are strictly read-only and confined to the configured log directory.
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/util"
+)
+
+func init() {
+	api.HandleAPIMethod(api.GET, "/logging/files", listLogFilesAction)
+	api.HandleAPIMethod(api.GET, "/logging/tail", tailLogFileAction)
+}
+
+const (
+	logTailMaxBytes   = 4 * 1024 * 1024 // scan at most the last 4MB of a file
+	logTailMaxLines   = 2000
+	logReadDirMaxDepth = 6
+)
+
+type logFileInfo struct {
+	Name    string `json:"name"`
+	Path    string `json:"path"`    // relative to the log dir; pass back to /logging/tail
+	Size    int64  `json:"size"`
+	Updated int64  `json:"updated"` // unix seconds
+	Current bool   `json:"current"` // most recently modified file
+}
+
+func logDirAbs() (string, error) {
+	dir := global.Env().GetLogDir()
+	if dir == "" {
+		return "", fmt.Errorf("log dir is not configured")
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// resolveLogFile validates that file (relative to the log dir, or absolute)
+// resolves inside the log dir, and returns its absolute path.
+func resolveLogFile(file string) (string, error) {
+	logDir, err := logDirAbs()
+	if err != nil {
+		return "", err
+	}
+	if file == "" {
+		return "", fmt.Errorf("file is required")
+	}
+	target := file
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(logDir, file)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	// resolve symlinks on both sides to prevent escaping via links
+	if resolvedLogDir, err := filepath.EvalSymlinks(logDir); err == nil {
+		logDir = resolvedLogDir
+	}
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", err
+	}
+	if resolved != logDir && !strings.HasPrefix(resolved, logDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("file [%v] is outside of the log directory", file)
+	}
+	return resolved, nil
+}
+
+func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	logDir, err := logDirAbs()
+	if err != nil {
+		api.DefaultAPI.WriteError(w, err.Error(), 500)
+		return
+	}
+
+	files := []logFileInfo{}
+	depth := 0
+	_ = filepath.Walk(logDir, func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if fi.IsDir() {
+			depth++
+			if depth > logReadDirMaxDepth {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		depth = 0
+		if !strings.HasSuffix(fi.Name(), ".log") && !strings.HasSuffix(fi.Name(), ".json") {
+			return nil
+		}
+		rel, err := filepath.Rel(logDir, p)
+		if err != nil {
+			return nil
+		}
+		files = append(files, logFileInfo{
+			Name:    filepath.ToSlash(rel),
+			Path:    filepath.ToSlash(rel),
+			Size:    fi.Size(),
+			Updated: fi.ModTime().Unix(),
+		})
+		return nil
+	})
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Updated != files[j].Updated {
+			return files[i].Updated > files[j].Updated
+		}
+		return files[i].Name < files[j].Name
+	})
+	if len(files) > 0 {
+		files[0].Current = true
+	}
+
+	api.DefaultAPI.WriteJSON(w, util.MapStr{
+		"log_dir": logDir,
+		"files":   files,
+	}, 200)
+}
+
+func tailLogFileAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	fileParam := req.URL.Query().Get("file")
+	absPath, err := resolveLogFile(fileParam)
+	if err != nil {
+		api.DefaultAPI.WriteError(w, err.Error(), 400)
+		return
+	}
+
+	lines, _ := strconv.Atoi(req.URL.Query().Get("lines"))
+	if lines == 0 {
+		lines = 200
+	}
+	if lines <= 0 {
+		lines = 200
+	}
+	if lines > logTailMaxLines {
+		lines = logTailMaxLines
+	}
+	keyword := strings.ToLower(strings.TrimSpace(req.URL.Query().Get("keyword")))
+
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		api.DefaultAPI.WriteError(w, fmt.Sprintf("stat file failed: %v", err), 400)
+		return
+	}
+
+	f, err := os.Open(absPath)
+	if err != nil {
+		api.DefaultAPI.WriteError(w, fmt.Sprintf("open file failed: %v", err), 400)
+		return
+	}
+	defer f.Close()
+
+	// read a bounded window from the end of the file
+	window := int64(logTailMaxBytes)
+	if fi.Size() < window {
+		window = fi.Size()
+	}
+	buf := make([]byte, window)
+	if _, err = f.ReadAt(buf, fi.Size()-window); err != nil && err.Error() != "EOF" {
+		api.DefaultAPI.WriteError(w, fmt.Sprintf("read file failed: %v", err), 500)
+		return
+	}
+
+	// drop the partial first line when we truncated mid-file
+	if window == logTailMaxBytes && len(buf) > 0 {
+		if idx := indexByte(buf, '\n'); idx >= 0 {
+			buf = buf[idx+1:]
+		}
+	}
+
+	rawLines := strings.Split(strings.ReplaceAll(string(buf), "\r\n", "\n"), "\n")
+	if n := len(rawLines); n > 0 && rawLines[n-1] == "" {
+		rawLines = rawLines[:n-1]
+	}
+
+	match := make([]string, 0, lines)
+	if keyword == "" {
+		if len(rawLines) > lines {
+			match = rawLines[len(rawLines)-lines:]
+		} else {
+			match = rawLines
+		}
+	} else {
+		for i := len(rawLines) - 1; i >= 0 && len(match) < lines; i-- {
+			if strings.Contains(strings.ToLower(rawLines[i]), keyword) {
+				match = append(match, rawLines[i])
+			}
+		}
+		// reversed above, restore chronological order
+		for i, j := 0, len(match)-1; i < j; i, j = i+1, j-1 {
+			match[i], match[j] = match[j], match[i]
+		}
+	}
+
+	api.DefaultAPI.WriteJSON(w, util.MapStr{
+		"file":       fileParam,
+		"size":       fi.Size(),
+		"updated":    fi.ModTime().Unix(),
+		"keyword":    keyword,
+		"truncated":  fi.Size() > logTailMaxBytes,
+		"lines":      match,
+		"server_time": time.Now().Unix(),
+	}, 200)
+}
+
+func indexByte(b []byte, c byte) int {
+	for i, v := range b {
+		if v == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/modules/configs/config/logging_files_test.go
+++ b/modules/configs/config/logging_files_test.go
@@ -1,0 +1,102 @@
+/* ©INFINI, All Rights Reserved.
+ * mail: contact#infini.ltd */
+
+package config
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	httprouter "infini.sh/framework/core/api/router"
+)
+
+func stubLogDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := currentLogDir
+	currentLogDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { currentLogDir = orig })
+}
+
+func callTail(t *testing.T, file string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/logging/tail?file="+url.QueryEscape(file), nil)
+	w := httptest.NewRecorder()
+	tailLogFileAction(w, req, httprouter.Params{})
+	return w
+}
+
+func TestTailLogFileAction(t *testing.T) {
+	dir := t.TempDir()
+	stubLogDir(t, dir)
+
+	logFile := filepath.Join(dir, "server.log")
+	content := "first\nsecond\nthird\n"
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := callTail(t, "server.log")
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "third") {
+		t.Errorf("expected tailed content in response: %s", w.Body.String())
+	}
+
+	for _, bad := range []string{
+		"../../../etc/passwd",
+		"/etc/passwd",
+		"missing.log",
+		"",
+	} {
+		if w := callTail(t, bad); w.Code != 400 {
+			t.Errorf("expected 400 for file [%q], got %d: %s", bad, w.Code, w.Body.String())
+		}
+	}
+
+	link := filepath.Join(dir, "escape.log")
+	if err := os.Symlink("/etc/passwd", link); err != nil {
+		t.Fatal(err)
+	}
+	if w := callTail(t, "escape.log"); w.Code != 400 {
+		t.Errorf("expected 400 for symlink escape, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListLogFilesAction(t *testing.T) {
+	dir := t.TempDir()
+	stubLogDir(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "server.log"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "nested", "slowlog.json"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/logging/files", nil)
+	w := httptest.NewRecorder()
+	listLogFilesAction(w, req, httprouter.Params{})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{"server.log", "nested/slowlog.json"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected [%s] in listing: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "notes.txt") {
+		t.Errorf("expected non-log file to be excluded: %s", body)
+	}
+}

--- a/modules/configs/config/logging_files_test.go
+++ b/modules/configs/config/logging_files_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -64,6 +65,49 @@ func TestTailLogFileAction(t *testing.T) {
 	}
 	if w := callTail(t, "escape.log"); w.Code != 400 {
 		t.Errorf("expected 400 for symlink escape, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListLogFilesActionRejectsSystemLogDir(t *testing.T) {
+	stubLogDir(t, "/etc")
+
+	req := httptest.NewRequest("GET", "/logging/files", nil)
+	w := httptest.NewRecorder()
+	listLogFilesAction(w, req, httprouter.Params{})
+	if w.Code != 500 {
+		t.Errorf("expected 500 for system path as log dir, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListLogFilesActionDepthResetsBetweenSiblings(t *testing.T) {
+	dir := t.TempDir()
+	stubLogDir(t, dir)
+
+	// a deep chain first so a buggy depth counter stays high, then a
+	// shallow sibling directory that must still be listed
+	deep := dir
+	for i := 0; i < logReadDirMaxDepth+2; i++ {
+		deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+	}
+	if err := os.MkdirAll(deep, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sibling := filepath.Join(dir, "shallow")
+	if err := os.Mkdir(sibling, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sibling, "server.log"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/logging/files", nil)
+	w := httptest.NewRecorder()
+	listLogFilesAction(w, req, httprouter.Params{})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "shallow/server.log") {
+		t.Errorf("expected shallow sibling file to be listed: %s", w.Body.String())
 	}
 }
 

--- a/modules/configs/reverseclient/reverse.go
+++ b/modules/configs/reverseclient/reverse.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/cihub/seelog"
@@ -148,11 +149,17 @@ func serve(conn *websocket.Conn) error {
 				hello := reverse.HelloMessage{
 					SessionID: sid,
 					PeerID:    global.Env().SystemConfig.NodeConfig.ID,
+					Features:  []string{reverse.CompressionGzip},
 				}
 				if err := send(conn, reverse.FormatHelloCommand(hello)); err != nil {
 					return err
 				}
 				log.Debugf("agent reverse channel hello sent for session [%s]", sid)
+			}
+		case reverse.FeaturesCommand:
+			// manager answered our capability advertisement
+			if fm, err := reverse.ParseFeaturePayload(payload1); err == nil {
+				managerGzipSupported.Store(fm.Gzip)
 			}
 		case reverse.RequestCommand:
 			go handleRequest(conn, payload1)
@@ -173,8 +180,15 @@ func send(conn *websocket.Conn, payload string) error {
 	return conn.WriteMessage(websocket.TextMessage, []byte(payload))
 }
 
+// managerGzipSupported flips true once the manager answers our HELLO
+// capability advertisement; until then responses stay uncompressed
+// (mixed-version safe: an old manager ignores the unknown feature frame).
+var managerGzipSupported atomic.Bool
+
 // handleRequest executes one proxied HTTP request against the agent's
-// own web port and streams the response back in chunks.
+// own web port and streams the response back in chunks. Bodies over the
+// compression threshold are gzipped when the manager advertised support,
+// flagged via ResponseMessage.Compressed.
 func handleRequest(conn *websocket.Conn, payload string) {
 	reqMsg, err := reverse.ParseRequestPayload(payload)
 	if err != nil {
@@ -184,9 +198,15 @@ func handleRequest(conn *websocket.Conn, payload string) {
 
 	status, body := execute(reqMsg)
 
+	compressed := false
+	if managerGzipSupported.Load() {
+		body, compressed = reverse.MaybeCompress(body)
+	}
+
 	resp := reverse.ResponseMessage{
-		RequestID: reqMsg.RequestID,
-		PeerID:    reqMsg.PeerID,
+		RequestID:  reqMsg.RequestID,
+		PeerID:     reqMsg.PeerID,
+		Compressed: compressed,
 	}
 	// chunk the body (base64) then a Done frame with the status
 	for offset := 0; offset < len(body); offset += 64 * 1024 {

--- a/modules/configs/server/enrollment_token.go
+++ b/modules/configs/server/enrollment_token.go
@@ -137,6 +137,18 @@ func consumeEnrollmentToken(ctx *orm.Context, t *EnrollmentToken) {
 	}
 }
 
+// CheckEnrollmentToken exposes ticket validation to sibling channels that
+// share the same admission pool (e.g. LogPilot's worker hub): same ORM
+// model, same hash scheme, same usage counters.
+func CheckEnrollmentToken(ctx *orm.Context, plaintext string) *EnrollmentToken {
+	return validateEnrollmentToken(ctx, plaintext)
+}
+
+// ConsumeEnrollmentToken exposes ticket consumption (use-counter increment).
+func ConsumeEnrollmentToken(ctx *orm.Context, t *EnrollmentToken) {
+	consumeEnrollmentToken(ctx, t)
+}
+
 func decodeEnrollmentHits(res *orm.SearchResult) ([]EnrollmentToken, int64, error) {
 	return elastic.DecodeHits[EnrollmentToken](res)
 }

--- a/modules/configs/server/reverse_channel.go
+++ b/modules/configs/server/reverse_channel.go
@@ -102,12 +102,15 @@ func onReverseConnect(sessionID string, w http.ResponseWriter, r *http.Request) 
 	inst.ID = instanceID
 	exists, err := orm.GetV2(ctx, &inst)
 	if err != nil && !isNotFound(err) {
+		log.Warnf("configs server: reverse connect [%s] instance lookup failed: %v", instanceID, err)
 		return err
 	}
 	if err != nil || !exists {
+		log.Warnf("configs server: reverse connect rejected: instance %s is not registered", instanceID)
 		return fmt.Errorf("instance %s is not registered", instanceID)
 	}
 	if loadInstanceStatus(ctx, instanceID) != StatusApproved {
+		log.Warnf("configs server: reverse connect rejected: instance %s is not approved", instanceID)
 		return fmt.Errorf("instance %s is not approved", instanceID)
 	}
 	// Credential check: the dial-out must authenticate like a sync would
@@ -120,6 +123,7 @@ func onReverseConnect(sessionID string, w http.ResponseWriter, r *http.Request) 
 	}
 	if !matchesManagerToken(ctx, instanceID, presented) &&
 		!matchesRegisteredAccessToken(ctx, instanceID, presented) {
+		log.Warnf("configs server: reverse connect rejected: instance %s credential check failed (token presented: %v)", instanceID, presented != "")
 		return fmt.Errorf("instance %s reverse channel credential rejected", instanceID)
 	}
 
@@ -137,10 +141,19 @@ func handleReverseHello(c *framework_ws.WebsocketConnection, array []string) {
 	if len(array) < 2 || reverseManager == nil {
 		return
 	}
-	if err := reverseManager.HandleHelloPayload(strings.Join(array[1:], " ")); err != nil {
+	features, err := reverseManager.HandleHelloPayload(strings.Join(array[1:], " "))
+	if err != nil {
 		log.Warnf("configs server: reverse hello rejected: %v", err)
-	} else {
-		log.Info("configs server: reverse hello accepted")
+		return
+	}
+	log.Info("configs server: reverse hello accepted")
+
+	// answer the peer's capability advertisement with our own, so both
+	// sides compress only when the other end supports it (old peers ignore
+	// this unknown command and stay on the uncompressed path)
+	if len(features) > 0 {
+		msg := reverse.FeatureMessage{Gzip: true}
+		_ = c.WritePrivateMessage(reverse.FormatFeatureCommand(msg))
 	}
 }
 

--- a/modules/configs/server/server.go
+++ b/modules/configs/server/server.go
@@ -216,6 +216,13 @@ func validateStaticToken(token string) bool {
 	return matched == 1
 }
 
+// ValidateStaticToken exposes static-token validation to sibling channels
+// that share the configs server's admission config (e.g. LogPilot's worker
+// hub accepts the same bootstrap tokens).
+func ValidateStaticToken(token string) bool {
+	return validateStaticToken(token)
+}
+
 // extractBearerToken reads the access token from the standard
 // Authorization: Bearer header, falling back to X-API-Token (the framework's
 // conventional token header).

--- a/modules/pipeline/module.go
+++ b/modules/pipeline/module.go
@@ -127,6 +127,18 @@ func (module *PipeModule) startTask(taskID string) (exists bool) {
 
 	exists = true
 
+	// A STOPPING pipeline is still winding down its processor chain (the
+	// consumer workers drain their in-flight batches before returning).
+	// Clearing the exit flag here would let keep_running resurrect the
+	// pipeline the moment Process returns — silently undoing the stop.
+	// Only an idle pipeline (STOPPED/FINISHED/FAILED) may be started.
+	if v1.GetRunningState() == pipeline.STOPPING {
+		if global.Env().IsDebug {
+			log.Debug("pipeline:", taskID, " is stopping, skip start until it settles")
+		}
+		return
+	}
+
 	// Mark exited pipeline to start again
 	if v1.IsExit() {
 		v1.Restart()

--- a/modules/queue/api.go
+++ b/modules/queue/api.go
@@ -52,6 +52,9 @@ func init() {
 	api.HandleAPIMethod(api.GET, "/queue/:id/stats", module.SingleQueueStatsAction)
 	api.HandleAPIMethod(api.GET, "/queue/:id/_scroll", module.QueueExplore)
 
+	//purge: drop all messages and consumed segments, keep the queue registration
+	api.HandleAPIMethod(api.POST, "/queue/:id/_empty", module.QueueEmptyAction)
+
 	api.HandleAPIMethod(api.DELETE, "/queue/:id", module.DeleteQueue)
 	api.HandleAPIMethod(api.DELETE, "/queue/_search", module.DeleteQueuesByQuery)
 
@@ -113,6 +116,24 @@ func (module *API) DeleteQueuesByQuery(w http.ResponseWriter, req *http.Request,
 func (module *API) DeleteQueue(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	id := ps.MustGetParameter("id")
 	module.deleteQueueByID(id)
+	module.WriteAckOKJSON(w)
+}
+
+// QueueEmptyAction — POST /queue/:id/_empty — 清空队列全部消息与已消费段
+// 文件 (释放磁盘), 保留队列注册与消费者; 位点越界的消费者自动重置到新头部。
+func (module *API) QueueEmptyAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	id := ps.MustGetParameter("id")
+	queueConfig, ok := queue1.SmartGetConfig(id)
+	if !ok || queueConfig == nil {
+		module.WriteError(w, fmt.Sprintf("queue [%v] not found", id), http.StatusNotFound)
+		return
+	}
+	if err := queue1.EmptyQueue(queueConfig); err != nil {
+		_ = log.Errorf("failed to empty queue [%v]: %v", id, err)
+		module.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	common.PersistQueueMetadata()
 	module.WriteAckOKJSON(w)
 }
 
@@ -272,6 +293,10 @@ func (module *API) QueueExplore(w http.ResponseWriter, req *http.Request, ps htt
 	queueID := ps.MustGetParameter("id")
 	offsetStr := module.GetParameterOrDefault(req, "offset", "0,0")
 	size := module.GetIntOrDefault(req, "size", 5)
+	// per-message response cap: dead-letter style queues can hold multi-MB
+	// bulk payloads, and unbounded sampling blows past reverse-channel and
+	// browser limits. 0 disables truncation.
+	maxMsgBytes := module.GetIntOrDefault(req, "max_msg_bytes", 256*1024)
 
 	group := module.GetParameterOrDefault(req, "group", "api")
 	name := module.GetParameterOrDefault(req, "name", "api")
@@ -299,13 +324,25 @@ func (module *API) QueueExplore(w http.ResponseWriter, req *http.Request, ps htt
 				msgs := []util.MapStr{}
 				for _, v := range messages {
 					msg := util.MapStr{}
-					msg["message"] = string(v.Data)
+					content := string(v.Data)
+					if maxMsgBytes > 0 && len(content) > maxMsgBytes {
+						content = content[:maxMsgBytes] + fmt.Sprintf("\n...[truncated %v of %v bytes]", len(v.Data)-maxMsgBytes, len(v.Data))
+						msg["truncated"] = true
+					}
+					msg["message"] = content
 					msg["offset"] = v.Offset.String()
 					msg["size"] = v.Size
 					msgs = append(msgs, msg)
 				}
 				result["messages"] = msgs
 			} else {
+				if maxMsgBytes > 0 {
+					for i := range messages {
+						if len(messages[i].Data) > maxMsgBytes {
+							messages[i].Data = messages[i].Data[:maxMsgBytes]
+						}
+					}
+				}
 				result["messages"] = messages
 			}
 

--- a/modules/queue/disk_queue/diskqueue.go
+++ b/modules/queue/disk_queue/diskqueue.go
@@ -57,6 +57,8 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -127,7 +129,7 @@ func NewDiskQueueByConfig(name, dataPath string, cfg *DiskQueueConfig) *DiskBase
 		writeChan:          make(chan []byte, cfg.WriteChanBuffer),
 		writeResponseChan:  make(chan WriteResponse),
 		emptyChan:          make(chan int),
-		emptyResponseChan:  make(chan error),
+		emptyResponseChan:  make(chan error, 1),
 		exitChan:           make(chan int),
 		exitSyncChan:       make(chan int, 10),
 		consumersInReading: sync.Map{},
@@ -345,10 +347,16 @@ func (d *DiskBasedQueue) exit(deleted bool) error {
 	return nil
 }
 
-// Empty destructively clears out any pending data in the queue
-// by fast forwarding read positions and removing intermediate files
+// Empty destructively clears out any pending data in the queue and drops
+// every segment file on disk (pending AND already-consumed), keeping the
+// queue registration intact. Positions reset to a fresh head; consumers
+// re-sync on their next read (missing files are handled gracefully).
+//
+// This must NOT round-trip through the ioLoop: Puts hold d.RLock() while
+// waiting for write responses, so a deleteAllFiles executing in the ioLoop
+// would deadlock against them. Taking the write lock directly here instead
+// serializes against in-flight Puts (each bounded by WriteTimeoutInMS).
 func (d *DiskBasedQueue) Empty() error {
-	d.RLock()
 	defer func() {
 		if !global.Env().IsDebug {
 			if r := recover(); r != nil {
@@ -364,7 +372,6 @@ func (d *DiskBasedQueue) Empty() error {
 				log.Error("error on empty disk_queue,", v)
 			}
 		}
-		d.RUnlock()
 	}()
 
 	if d.exitFlag == 1 {
@@ -373,23 +380,90 @@ func (d *DiskBasedQueue) Empty() error {
 
 	log.Tracef("disk_queue(%s): emptying", d.name)
 
-	d.emptyChan <- 1
-	return <-d.emptyResponseChan
-}
-
-func (d *DiskBasedQueue) deleteAllFiles() error {
-	err := d.skipToNextRWFile(true)
-
-	innerErr := os.Remove(d.metaDataFileName())
-	if innerErr != nil && !os.IsNotExist(innerErr) {
-		log.Errorf("diskqueue(%s) failed to remove metadata file - %s", d.name, innerErr)
-		return innerErr
+	// Snapshot the ACTUAL segment files on disk instead of synthesizing names
+	// from the in-memory counter: after metadata loss/resets across restarts,
+	// the directory commonly holds orphaned segments from earlier eras that no
+	// counter-based cleanup will ever reach.
+	d.Lock()
+	// find the highest segment actually on disk so the fresh head jumps past
+	// every file ever written — including orphans above the in-memory counter
+	// left behind by metadata loss across restarts — so segment numbers are
+	// never reused over stale bytes
+	maxSeg := d.writeSegmentNum
+	if entries, err := os.ReadDir(d.dataPath); err == nil {
+		for _, e := range entries {
+			if seg, ok := segmentNumOf(e.Name()); ok && seg > maxSeg {
+				maxSeg = seg
+			}
+		}
 	}
+	// close open handles and jump to a fresh head with cleared positions
+	if d.readFile != nil {
+		_ = d.readFile.Close()
+		d.readFile = nil
+	}
+	if d.writeFile != nil {
+		_ = d.writeFile.Sync()
+		_ = d.writeFile.Close()
+		d.writeFile = nil
+	}
+	d.writeSegmentNum = maxSeg + 1
+	d.writePos = 0
+	d.readSegmentFileNum = d.writeSegmentNum
+	d.readPos = 0
+	d.nextReadFileNum = d.writeSegmentNum
+	d.nextReadPos = 0
+	d.depth = 0
+	d.needSync = true
+	metaFile := d.metaDataFileName()
+	dataPath := d.dataPath
+	d.Unlock()
 
-	return err
+	// every file currently on disk is stale: the fresh head is a brand-new
+	// segment number nothing points at
+	stale := make([]string, 0, 64)
+	if entries, err := os.ReadDir(dataPath); err == nil {
+		metaName := path.Base(metaFile)
+		for _, e := range entries {
+			n := e.Name()
+			if n == metaName || strings.HasPrefix(n, metaName+".") {
+				continue
+			}
+			stale = append(stale, path.Join(dataPath, n))
+		}
+	} else {
+		log.Errorf("diskqueue(%s): empty ReadDir(%v) failed: %v", d.name, dataPath, err)
+	}
+	log.Infof("diskqueue(%s): empty head=%v, %v files to unlink, dataPath=%v", d.name, d.writeSegmentNum, len(stale), dataPath)
+
+	// unlink outside the lock; writers race on the fresh head, which is kept
+	go func() {
+		for _, f := range stale {
+			if rmErr := os.Remove(f); rmErr != nil && !os.IsNotExist(rmErr) {
+				log.Errorf("diskqueue(%s) failed to remove data file [%s] - %s", d.name, f, rmErr)
+			}
+		}
+		if rmErr := os.Remove(metaFile); rmErr != nil && !os.IsNotExist(rmErr) {
+			log.Errorf("diskqueue(%s) failed to remove metadata file - %s", d.name, rmErr)
+		}
+	}()
+
+	return nil
 }
 
-// 删除中间的错误文件，跳转到最后一个可写文件
+// segmentNumOf parses "<zero-padded N>.dat[.zstd]" segment file names.
+func segmentNumOf(name string) (int64, bool) {
+	name = strings.TrimSuffix(name, compressFileSuffix)
+	if !strings.HasSuffix(name, ".dat") {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.TrimSuffix(name, ".dat"), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
 func (d *DiskBasedQueue) skipToNextRWFile(delete bool) error {
 	d.Lock()
 	defer d.Unlock()
@@ -961,9 +1035,6 @@ func (d *DiskBasedQueue) ioLoop() {
 			// readMoveForward sets needSync flag if a file is removed
 			d.readMoveForward()
 		case d.depthChan <- d.depth:
-		case <-d.emptyChan:
-			d.emptyResponseChan <- d.deleteAllFiles()
-			count = 0
 		case dataWrite := <-d.writeChan:
 			count++
 			d.writeResponseChan <- d.writeOne(dataWrite)

--- a/modules/queue/disk_queue/empty_concurrent_test.go
+++ b/modules/queue/disk_queue/empty_concurrent_test.go
@@ -1,0 +1,116 @@
+package queue
+
+import (
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/kv"
+)
+
+type concKV struct{ data map[string][]byte }
+
+func (m *concKV) Open() error  { return nil }
+func (m *concKV) Close() error { return nil }
+func (m *concKV) GetValue(b string, k []byte) ([]byte, error) {
+	if v, ok := m.data[string(k)]; ok {
+		return append([]byte(nil), v...), nil
+	}
+	return nil, nil
+}
+func (m *concKV) GetCompressedValue(b string, k []byte) ([]byte, error) { return m.GetValue(b, k) }
+func (m *concKV) AddValueCompress(b string, k, v []byte) error         { return m.AddValue(b, k, v) }
+func (m *concKV) AddValue(b string, k, v []byte) error {
+	m.data[string(k)] = append([]byte(nil), v...)
+	return nil
+}
+func (m *concKV) ExistsKey(b string, k []byte) (bool, error) {
+	_, ok := m.data[string(k)]
+	return ok, nil
+}
+func (m *concKV) DeleteKey(b string, k []byte) error {
+	delete(m.data, string(k))
+	return nil
+}
+
+func init() {
+	kv.Register("test-conc-kv", &concKV{data: map[string][]byte{}})
+}
+
+func TestEmptyUnderConcurrentTraffic(t *testing.T) {
+	global.Env().SystemConfig.PathConfig.Data = t.TempDir()
+	name := "test-empty-conc"
+	dataPath := GetDataPath(name)
+	_ = os.MkdirAll(dataPath, 0755)
+
+	cfg := &DiskQueueConfig{
+		MinMsgSize: 1, MaxMsgSize: 104857600,
+		MaxBytesPerFile: 1024, SyncEveryRecords: 1, SyncTimeoutInMS: 10,
+		WriteTimeoutInMS: 1000, EOFRetryDelayInMs: 100,
+		ReadChanBuffer: 10, WriteChanBuffer: 10,
+		PrepareFilesToRead: true,
+	}
+	d := NewDiskQueueByConfig(name, dataPath, cfg)
+	defer d.Close()
+
+	var stop int32
+	// producer
+	go func() {
+		for atomic.LoadInt32(&stop) == 0 {
+			d.Put([]byte("0123456789abcdef0123456789abcdef0123456789abcdef"))
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	// consumer
+	go func() {
+		for atomic.LoadInt32(&stop) == 0 {
+			select {
+			case <-d.ReadChan():
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+	}()
+
+	time.Sleep(2 * time.Second) // let segments accumulate
+
+	// simulate orphaned segments from earlier eras ABOVE the in-memory counter
+	// (metadata loss across restarts) — they must be purged too
+	for _, orphan := range []string{"000000200.dat", "000000201.dat", "000000201.dat.zstd"} {
+		if werr := os.WriteFile(filepath.Join(dataPath, orphan), []byte("orphan"), 0644); werr != nil {
+			t.Fatal(werr)
+		}
+	}
+
+	start := time.Now()
+	err := d.Empty()
+	elapsed := time.Since(start)
+	atomic.StoreInt32(&stop, 1)
+	if err != nil {
+		// dump goroutines to see where ioLoop / deleteAllFiles is stuck
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+		t.Fatalf("empty: %v (took %v)", err, elapsed)
+	}
+	t.Logf("empty took %v", elapsed)
+
+	time.Sleep(1 * time.Second)
+	files := 0
+	filepath.Walk(dataPath, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() {
+			files++
+		}
+		return nil
+	})
+	t.Logf("files after empty: %v", files)
+	if files > 3 {
+		t.Fatalf("expected stale segments gone, got %v files", files)
+	}
+	for _, orphan := range []string{"000000200.dat", "000000201.dat", "000000201.dat.zstd"} {
+		if _, err := os.Stat(filepath.Join(dataPath, orphan)); !os.IsNotExist(err) {
+			t.Fatalf("orphan %v survived empty", orphan)
+		}
+	}
+}

--- a/modules/queue/disk_queue/empty_test.go
+++ b/modules/queue/disk_queue/empty_test.go
@@ -1,0 +1,116 @@
+package queue
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/kv"
+)
+
+type memKV struct{ data map[string][]byte }
+
+func (m *memKV) Open() error                                     { return nil }
+func (m *memKV) Close() error                                    { return nil }
+func (m *memKV) GetValue(b string, k []byte) ([]byte, error) {
+	if v, ok := m.data[string(k)]; ok { return append([]byte(nil), v...), nil }
+	return nil, nil
+}
+func (m *memKV) GetCompressedValue(b string, k []byte) ([]byte, error) { return m.GetValue(b, k) }
+func (m *memKV) AddValueCompress(b string, k, v []byte) error          { return m.AddValue(b, k, v) }
+func (m *memKV) AddValue(b string, k, v []byte) error {
+	m.data[string(k)] = append([]byte(nil), v...)
+	return nil
+}
+func (m *memKV) ExistsKey(b string, k []byte) (bool, error) {
+	_, ok := m.data[string(k)]
+	return ok, nil
+}
+func (m *memKV) DeleteKey(b string, k []byte) error {
+	delete(m.data, string(k))
+	return nil
+}
+
+func init() {
+	kv.Register("test-mem-kv", &memKV{data: map[string][]byte{}})
+}
+
+func TestEmptyRemovesConsumedSegments(t *testing.T) {
+	global.Env().SystemConfig.PathConfig.Data = t.TempDir()
+	name := "test-empty-queue"
+	dataPath := GetDataPath(name)
+	_ = os.MkdirAll(dataPath, 0755)
+
+	cfg := &DiskQueueConfig{
+		MinMsgSize:       1,
+		MaxMsgSize:       104857600,
+		MaxBytesPerFile:  1024, // small segments: multiple files quickly
+		SyncEveryRecords: 1,
+		SyncTimeoutInMS:  10,
+		WriteTimeoutInMS: 1000,
+		EOFRetryDelayInMs: 100,
+		ReadChanBuffer:   10,
+		WriteChanBuffer:  10,
+	}
+	d := NewDiskQueueByConfig(name, dataPath, cfg)
+	defer d.Close()
+
+	// write enough records to roll several 1KB segments
+	for i := 0; i < 200; i++ {
+		res := d.Put([]byte("0123456789abcdef0123456789abcdef0123456789abcdef"))
+		if res.Error != nil {
+			t.Fatalf("put: %v", res.Error)
+		}
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	// consume everything so depth returns to 0 (consumed segments retained)
+	read := 0
+	for read < 200 {
+		select {
+		case <-d.ReadChan():
+			read++
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout consuming, read=%v", read)
+		}
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	filesBefore := 0
+	filepath.Walk(dataPath, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() {
+			filesBefore++
+		}
+		return nil
+	})
+	if filesBefore == 0 {
+		t.Fatal("no segment files before empty")
+	}
+
+	// the behavior under test: Empty drops ALL segment files, fast
+	start := time.Now()
+	if err := d.Empty(); err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Fatalf("empty took too long: %v", elapsed)
+	}
+
+	time.Sleep(500 * time.Millisecond) // async unlink
+	filesAfter := 0
+	filepath.Walk(dataPath, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() && filepath.Base(p) != "meta.dat" {
+			filesAfter++
+		}
+		return nil
+	})
+	if filesAfter != 0 {
+		t.Fatalf("expected 0 segment files after empty, got %v", filesAfter)
+	}
+	if d.Depth() != 0 {
+		t.Fatalf("expected depth 0, got %v", d.Depth())
+	}
+}

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -403,6 +403,24 @@ func (module *DiskQueue) Close(k string) error {
 	panic(errors.Errorf("queue [%v] not found", k))
 }
 
+// Empty drops all messages and consumed segment files of one queue while
+// keeping the queue registration and its consumers intact — the purge
+// behind POST /queue/:id/_empty. Not-found queues init on demand instead
+// of erroring (consistent with GetStorageSize).
+func (module *DiskQueue) Empty(k string) error {
+	q, ok := module.queues.Load(k)
+	if !ok {
+		if err := module.Init(k); err != nil {
+			return err
+		}
+		q, ok = module.queues.Load(k)
+		if !ok {
+			return errors.Errorf("queue [%v] not found", k)
+		}
+	}
+	return (q.(*DiskBasedQueue)).Empty()
+}
+
 func (module *DiskQueue) GetStorageSize(k string) uint64 {
 	q, ok := module.queues.Load(k)
 	if !ok {

--- a/plugins/queue/consumer/consumer.go
+++ b/plugins/queue/consumer/consumer.go
@@ -24,6 +24,7 @@
 package consumer
 
 import (
+	"context"
 	"fmt"
 	"infini.sh/framework/core/errors"
 	"infini.sh/framework/core/locker"
@@ -403,6 +404,12 @@ func (processor *QueueConsumerProcessor) HandleQueueConfig(qConfig *queue.QueueC
 			if err != nil {
 				panic(err)
 			}
+			// this spawn is a retry: give back one failure credit so a
+			// slice that recovers isn't latched out forever after a single
+			// failed worker (the counter previously only ever grew)
+			if ctx.Stats(sliceStats) > 0 {
+				ctx.Increment(sliceStats, -1)
+			}
 		}
 	}
 	return nil
@@ -672,7 +679,16 @@ READ_DOCS:
 			newCtx := pipeline.Context{}
 			newCtx.ParentContext = ctx
 			newCtx.Config = ctx.Config
-			newCtx.Context = ctx.Context
+			// Derive the sub-chain context from the owning pipeline's context
+			// (worker context as fallback): pipeline cancellation must reach
+			// the per-record loop inside the sub-chain, otherwise a stop only
+			// takes effect between fetches — with slow processors and deep
+			// queues that leaves a stopped pipeline draining for minutes.
+			subCtx, cancelSub := context.WithCancel(context.Background())
+			if parentContext != nil {
+				subCtx, cancelSub = context.WithCancel(parentContext.Context)
+			}
+			newCtx.Context = subCtx
 			newCtx.Data = ctx.CloneData()
 
 			_, err := newCtx.PutValue(processor.config.QueueField, qConfig.Name)
@@ -697,11 +713,17 @@ READ_DOCS:
 
 			//log.Error("start processing message:",len(messages),",",qConfig.Name)
 			err = processor.processors.Process(&newCtx)
+			cancelSub()
 			//log.Error("end processing message:",len(messages),",",qConfig.Name,",",err)
 			if err != nil {
 				panic(err)
 			}
-			offset = ctx1.NextOffset //TODO
+			// Only consume the batch when the pipeline is not stopping: a
+			// batch interrupted mid-processing keeps the previous offset so
+			// it is re-delivered next run (at-least-once).
+			if parentContext == nil || !parentContext.IsCanceled() {
+				offset = ctx1.NextOffset //TODO
+			}
 			messages = nil
 		} else {
 			EOF = true


### PR DESCRIPTION
## Summary

Branch carries the worker-hub token helpers plus this round of queue/pipeline reliability work:

- **feat(configs)**: export enrollment/static token validation helpers (ConsumeEnrollmentToken / CheckEnrollmentToken / ValidateStaticToken) for hub integrations
- **fix(pipeline,queue)**: new queue purge API (`POST /queue/:id/_empty`) with rewritten `Empty` semantics (no ioLoop deadlock, head jumps past orphaned segments, async unlink); pipeline `startTask` no longer resurrects a STOPPING pipeline; queue consumer derives its sub-chain context from the owning pipeline so cancellation interrupts mid-batch, keeps offsets on interrupted batches, and no longer latches a queue out after a single failed slice worker
- **feat(reverse)**: reverse-channel response compression (`compressed` flag + gzip) with HELLO capability negotiation (mixed-version safe); 8MB cap now applies to compressed wire bytes; connect rejections log their reason
- **feat(configs)**: read-only instance log tail API (`/logging/files`, `/logging/tail`) so consoles can troubleshoot instances through the reverse channel
- **fix(model)**: unbalanced brace in `instance.groups` elastic_mapping panicked schema init on template recreation

## Test plan

- `go build ./...` + unit tests for pipeline module, queue consumer, and the new compression round-trip / Empty (sequential + concurrent) tests
- Staged on a live agent + gateway + logpilot trio: purge verified against ~14GB of stale queue segments, pipeline stop/start now settles in seconds, compressed tail responses round-trip through the proxy

🤖 Generated with ZCode