### PR TITLE
feat(configs): export enrollment/static token validation helpers

### DIFF
--- a/modules/configs/server/enrollment_token.go
+++ b/modules/configs/server/enrollment_token.go
@@ -137,6 +137,18 @@ func consumeEnrollmentToken(ctx *orm.Context, t *EnrollmentToken) {
 	}
 }
 
+// CheckEnrollmentToken exposes ticket validation to sibling channels that
+// share the same admission pool (e.g. LogPilot's worker hub): same ORM
+// model, same hash scheme, same usage counters.
+func CheckEnrollmentToken(ctx *orm.Context, plaintext string) *EnrollmentToken {
+	return validateEnrollmentToken(ctx, plaintext)
+}
+
+// ConsumeEnrollmentToken exposes ticket consumption (use-counter increment).
+func ConsumeEnrollmentToken(ctx *orm.Context, t *EnrollmentToken) {
+	consumeEnrollmentToken(ctx, t)
+}
+
 func decodeEnrollmentHits(res *orm.SearchResult) ([]EnrollmentToken, int64, error) {
 	return elastic.DecodeHits[EnrollmentToken](res)
 }

--- a/modules/configs/server/server.go
+++ b/modules/configs/server/server.go
@@ -216,6 +216,13 @@ func validateStaticToken(token string) bool {
 	return matched == 1
 }
 
+// ValidateStaticToken exposes static-token validation to sibling channels
+// that share the configs server's admission config (e.g. LogPilot's worker
+// hub accepts the same bootstrap tokens).
+func ValidateStaticToken(token string) bool {
+	return validateStaticToken(token)
+}
+
 // extractBearerToken reads the access token from the standard
 // Authorization: Bearer header, falling back to X-API-Token (the framework's
 // conventional token header).


### PR DESCRIPTION
## Summary

Export the enrollment/static token validation helpers (`ConsumeEnrollmentToken`, `CheckEnrollmentToken`, `ValidateStaticToken`) so hub integrations can reuse the server-side token flow without duplicating it.

Split from #416.

## Test plan

- `go build ./modules/configs/...` + `go test ./modules/configs/...`

🤖 Generated with ZCode