### PR TITLE
fix(pipeline,queue): safe queue purge API and stop/latch fixes

### DIFF
--- a/core/queue/api.go
+++ b/core/queue/api.go
@@ -82,6 +82,29 @@ type ConsumerAPI interface {
 	CommitOffset(offset Offset) error
 }
 
+// QueuePurgeAPI is an optional handler capability: drop all buffered
+// messages and already-consumed segment files without destroying the queue
+// registration itself. Handlers without purge support (e.g. kafka) simply
+// don't implement it.
+type QueuePurgeAPI interface {
+	Empty(k string) error
+}
+
+// EmptyQueue purges every message of a queue through its handler's purge
+// support. Consumers and offsets are kept: disk-queue consumers resume from
+// the fresh head (out-of-range offsets auto-reset).
+// NOTE: keyed by k.ID — the handlers' storage and instance maps are ID-keyed.
+func EmptyQueue(k *QueueConfig) error {
+	if k == nil || k.ID == "" {
+		return errors.New("invalid queue config")
+	}
+	handler := GetHandlerByType(k.Type)
+	if h, ok := handler.(QueuePurgeAPI); ok {
+		return h.Empty(k.ID)
+	}
+	return errors.Errorf("queue type [%v] does not support purging", k.Type)
+}
+
 var defaultHandler QueueAPI
 
 func getSimpleHandler(k *QueueConfig) SimpleQueueAPI {

--- a/modules/pipeline/module.go
+++ b/modules/pipeline/module.go
@@ -127,6 +127,18 @@ func (module *PipeModule) startTask(taskID string) (exists bool) {
 
 	exists = true
 
+	// A STOPPING pipeline is still winding down its processor chain (the
+	// consumer workers drain their in-flight batches before returning).
+	// Clearing the exit flag here would let keep_running resurrect the
+	// pipeline the moment Process returns — silently undoing the stop.
+	// Only an idle pipeline (STOPPED/FINISHED/FAILED) may be started.
+	if v1.GetRunningState() == pipeline.STOPPING {
+		if global.Env().IsDebug {
+			log.Debug("pipeline:", taskID, " is stopping, skip start until it settles")
+		}
+		return
+	}
+
 	// Mark exited pipeline to start again
 	if v1.IsExit() {
 		v1.Restart()

--- a/modules/queue/api.go
+++ b/modules/queue/api.go
@@ -52,6 +52,9 @@ func init() {
 	api.HandleAPIMethod(api.GET, "/queue/:id/stats", module.SingleQueueStatsAction)
 	api.HandleAPIMethod(api.GET, "/queue/:id/_scroll", module.QueueExplore)
 
+	//purge: drop all messages and consumed segments, keep the queue registration
+	api.HandleAPIMethod(api.POST, "/queue/:id/_empty", module.QueueEmptyAction)
+
 	api.HandleAPIMethod(api.DELETE, "/queue/:id", module.DeleteQueue)
 	api.HandleAPIMethod(api.DELETE, "/queue/_search", module.DeleteQueuesByQuery)
 
@@ -113,6 +116,24 @@ func (module *API) DeleteQueuesByQuery(w http.ResponseWriter, req *http.Request,
 func (module *API) DeleteQueue(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	id := ps.MustGetParameter("id")
 	module.deleteQueueByID(id)
+	module.WriteAckOKJSON(w)
+}
+
+// QueueEmptyAction — POST /queue/:id/_empty — 清空队列全部消息与已消费段
+// 文件 (释放磁盘), 保留队列注册与消费者; 位点越界的消费者自动重置到新头部。
+func (module *API) QueueEmptyAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	id := ps.MustGetParameter("id")
+	queueConfig, ok := queue1.SmartGetConfig(id)
+	if !ok || queueConfig == nil {
+		module.WriteError(w, fmt.Sprintf("queue [%v] not found", id), http.StatusNotFound)
+		return
+	}
+	if err := queue1.EmptyQueue(queueConfig); err != nil {
+		_ = log.Errorf("failed to empty queue [%v]: %v", id, err)
+		module.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	common.PersistQueueMetadata()
 	module.WriteAckOKJSON(w)
 }
 
@@ -272,6 +293,10 @@ func (module *API) QueueExplore(w http.ResponseWriter, req *http.Request, ps htt
 	queueID := ps.MustGetParameter("id")
 	offsetStr := module.GetParameterOrDefault(req, "offset", "0,0")
 	size := module.GetIntOrDefault(req, "size", 5)
+	// per-message response cap: dead-letter style queues can hold multi-MB
+	// bulk payloads, and unbounded sampling blows past reverse-channel and
+	// browser limits. 0 disables truncation.
+	maxMsgBytes := module.GetIntOrDefault(req, "max_msg_bytes", 256*1024)
 
 	group := module.GetParameterOrDefault(req, "group", "api")
 	name := module.GetParameterOrDefault(req, "name", "api")
@@ -299,13 +324,25 @@ func (module *API) QueueExplore(w http.ResponseWriter, req *http.Request, ps htt
 				msgs := []util.MapStr{}
 				for _, v := range messages {
 					msg := util.MapStr{}
-					msg["message"] = string(v.Data)
+					content := string(v.Data)
+					if maxMsgBytes > 0 && len(content) > maxMsgBytes {
+						content = content[:maxMsgBytes] + fmt.Sprintf("\n...[truncated %v of %v bytes]", len(v.Data)-maxMsgBytes, len(v.Data))
+						msg["truncated"] = true
+					}
+					msg["message"] = content
 					msg["offset"] = v.Offset.String()
 					msg["size"] = v.Size
 					msgs = append(msgs, msg)
 				}
 				result["messages"] = msgs
 			} else {
+				if maxMsgBytes > 0 {
+					for i := range messages {
+						if len(messages[i].Data) > maxMsgBytes {
+							messages[i].Data = messages[i].Data[:maxMsgBytes]
+						}
+					}
+				}
 				result["messages"] = messages
 			}
 

--- a/modules/queue/api.go
+++ b/modules/queue/api.go
@@ -119,8 +119,10 @@ func (module *API) DeleteQueue(w http.ResponseWriter, req *http.Request, ps http
 	module.WriteAckOKJSON(w)
 }
 
-// QueueEmptyAction — POST /queue/:id/_empty — 清空队列全部消息与已消费段
-// 文件 (释放磁盘), 保留队列注册与消费者; 位点越界的消费者自动重置到新头部。
+// QueueEmptyAction handles POST /queue/:id/_empty: drop all buffered
+// messages and consumed segment files (releases disk space) while keeping
+// the queue registration and its consumers; consumers whose offsets fall
+// out of range auto-reset to the fresh head.
 func (module *API) QueueEmptyAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	id := ps.MustGetParameter("id")
 	queueConfig, ok := queue1.SmartGetConfig(id)

--- a/modules/queue/disk_queue/diskqueue.go
+++ b/modules/queue/disk_queue/diskqueue.go
@@ -57,6 +57,8 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -127,7 +129,7 @@ func NewDiskQueueByConfig(name, dataPath string, cfg *DiskQueueConfig) *DiskBase
 		writeChan:          make(chan []byte, cfg.WriteChanBuffer),
 		writeResponseChan:  make(chan WriteResponse),
 		emptyChan:          make(chan int),
-		emptyResponseChan:  make(chan error),
+		emptyResponseChan:  make(chan error, 1),
 		exitChan:           make(chan int),
 		exitSyncChan:       make(chan int, 10),
 		consumersInReading: sync.Map{},
@@ -345,10 +347,16 @@ func (d *DiskBasedQueue) exit(deleted bool) error {
 	return nil
 }
 
-// Empty destructively clears out any pending data in the queue
-// by fast forwarding read positions and removing intermediate files
+// Empty destructively clears out any pending data in the queue and drops
+// every segment file on disk (pending AND already-consumed), keeping the
+// queue registration intact. Positions reset to a fresh head; consumers
+// re-sync on their next read (missing files are handled gracefully).
+//
+// This must NOT round-trip through the ioLoop: Puts hold d.RLock() while
+// waiting for write responses, so a deleteAllFiles executing in the ioLoop
+// would deadlock against them. Taking the write lock directly here instead
+// serializes against in-flight Puts (each bounded by WriteTimeoutInMS).
 func (d *DiskBasedQueue) Empty() error {
-	d.RLock()
 	defer func() {
 		if !global.Env().IsDebug {
 			if r := recover(); r != nil {
@@ -364,7 +372,6 @@ func (d *DiskBasedQueue) Empty() error {
 				log.Error("error on empty disk_queue,", v)
 			}
 		}
-		d.RUnlock()
 	}()
 
 	if d.exitFlag == 1 {
@@ -373,23 +380,90 @@ func (d *DiskBasedQueue) Empty() error {
 
 	log.Tracef("disk_queue(%s): emptying", d.name)
 
-	d.emptyChan <- 1
-	return <-d.emptyResponseChan
-}
-
-func (d *DiskBasedQueue) deleteAllFiles() error {
-	err := d.skipToNextRWFile(true)
-
-	innerErr := os.Remove(d.metaDataFileName())
-	if innerErr != nil && !os.IsNotExist(innerErr) {
-		log.Errorf("diskqueue(%s) failed to remove metadata file - %s", d.name, innerErr)
-		return innerErr
+	// Snapshot the ACTUAL segment files on disk instead of synthesizing names
+	// from the in-memory counter: after metadata loss/resets across restarts,
+	// the directory commonly holds orphaned segments from earlier eras that no
+	// counter-based cleanup will ever reach.
+	d.Lock()
+	// find the highest segment actually on disk so the fresh head jumps past
+	// every file ever written — including orphans above the in-memory counter
+	// left behind by metadata loss across restarts — so segment numbers are
+	// never reused over stale bytes
+	maxSeg := d.writeSegmentNum
+	if entries, err := os.ReadDir(d.dataPath); err == nil {
+		for _, e := range entries {
+			if seg, ok := segmentNumOf(e.Name()); ok && seg > maxSeg {
+				maxSeg = seg
+			}
+		}
 	}
+	// close open handles and jump to a fresh head with cleared positions
+	if d.readFile != nil {
+		_ = d.readFile.Close()
+		d.readFile = nil
+	}
+	if d.writeFile != nil {
+		_ = d.writeFile.Sync()
+		_ = d.writeFile.Close()
+		d.writeFile = nil
+	}
+	d.writeSegmentNum = maxSeg + 1
+	d.writePos = 0
+	d.readSegmentFileNum = d.writeSegmentNum
+	d.readPos = 0
+	d.nextReadFileNum = d.writeSegmentNum
+	d.nextReadPos = 0
+	d.depth = 0
+	d.needSync = true
+	metaFile := d.metaDataFileName()
+	dataPath := d.dataPath
+	d.Unlock()
 
-	return err
+	// every file currently on disk is stale: the fresh head is a brand-new
+	// segment number nothing points at
+	stale := make([]string, 0, 64)
+	if entries, err := os.ReadDir(dataPath); err == nil {
+		metaName := path.Base(metaFile)
+		for _, e := range entries {
+			n := e.Name()
+			if n == metaName || strings.HasPrefix(n, metaName+".") {
+				continue
+			}
+			stale = append(stale, path.Join(dataPath, n))
+		}
+	} else {
+		log.Errorf("diskqueue(%s): empty ReadDir(%v) failed: %v", d.name, dataPath, err)
+	}
+	log.Infof("diskqueue(%s): empty head=%v, %v files to unlink, dataPath=%v", d.name, d.writeSegmentNum, len(stale), dataPath)
+
+	// unlink outside the lock; writers race on the fresh head, which is kept
+	go func() {
+		for _, f := range stale {
+			if rmErr := os.Remove(f); rmErr != nil && !os.IsNotExist(rmErr) {
+				log.Errorf("diskqueue(%s) failed to remove data file [%s] - %s", d.name, f, rmErr)
+			}
+		}
+		if rmErr := os.Remove(metaFile); rmErr != nil && !os.IsNotExist(rmErr) {
+			log.Errorf("diskqueue(%s) failed to remove metadata file - %s", d.name, rmErr)
+		}
+	}()
+
+	return nil
 }
 
-// 删除中间的错误文件，跳转到最后一个可写文件
+// segmentNumOf parses "<zero-padded N>.dat[.zstd]" segment file names.
+func segmentNumOf(name string) (int64, bool) {
+	name = strings.TrimSuffix(name, compressFileSuffix)
+	if !strings.HasSuffix(name, ".dat") {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.TrimSuffix(name, ".dat"), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
 func (d *DiskBasedQueue) skipToNextRWFile(delete bool) error {
 	d.Lock()
 	defer d.Unlock()
@@ -961,9 +1035,6 @@ func (d *DiskBasedQueue) ioLoop() {
 			// readMoveForward sets needSync flag if a file is removed
 			d.readMoveForward()
 		case d.depthChan <- d.depth:
-		case <-d.emptyChan:
-			d.emptyResponseChan <- d.deleteAllFiles()
-			count = 0
 		case dataWrite := <-d.writeChan:
 			count++
 			d.writeResponseChan <- d.writeOne(dataWrite)

--- a/modules/queue/disk_queue/diskqueue.go
+++ b/modules/queue/disk_queue/diskqueue.go
@@ -108,7 +108,7 @@ type DiskBasedQueue struct {
 	writeChan         chan []byte
 	writeResponseChan chan WriteResponse
 	emptyChan         chan int
-	emptyResponseChan chan error
+	emptyResponseChan chan emptyResult
 	exitChan          chan int
 	exitSyncChan      chan int
 
@@ -129,7 +129,7 @@ func NewDiskQueueByConfig(name, dataPath string, cfg *DiskQueueConfig) *DiskBase
 		writeChan:          make(chan []byte, cfg.WriteChanBuffer),
 		writeResponseChan:  make(chan WriteResponse),
 		emptyChan:          make(chan int),
-		emptyResponseChan:  make(chan error, 1),
+		emptyResponseChan:  make(chan emptyResult, 1),
 		exitChan:           make(chan int),
 		exitSyncChan:       make(chan int, 10),
 		consumersInReading: sync.Map{},
@@ -352,51 +352,99 @@ func (d *DiskBasedQueue) exit(deleted bool) error {
 // queue registration intact. Positions reset to a fresh head; consumers
 // re-sync on their next read (missing files are handled gracefully).
 //
-// This must NOT round-trip through the ioLoop: Puts hold d.RLock() while
-// waiting for write responses, so a deleteAllFiles executing in the ioLoop
-// would deadlock against them. Taking the write lock directly here instead
-// serializes against in-flight Puts (each bounded by WriteTimeoutInMS).
+// Empty destructively clears out any pending data in the queue and drops
+// every segment file on disk (pending AND already-consumed), keeping the
+// queue registration intact. Positions reset to a fresh head; consumers
+// re-sync on their next read (missing files are handled gracefully).
+//
+// The purge itself runs INSIDE the ioLoop, the single writer that owns the
+// segment/position/file-handle state, so it is race-free by construction.
+// Empty holds no lock while waiting for it: Puts hold d.RLock() while
+// waiting for write responses, so a purge that needed d.Lock() from inside
+// the ioLoop (the old deleteAllFiles) would deadlock against them, and a
+// purge taking d.Lock() outside the ioLoop races against its unlocked
+// field accesses. Signaling over emptyChan serializes with in-flight
+// writes instead: Puts queue behind the purge in writeChan, each bounded
+// by WriteTimeoutInMS.
 func (d *DiskBasedQueue) Empty() error {
-	defer func() {
-		if !global.Env().IsDebug {
-			if r := recover(); r != nil {
-				var v string
-				switch r.(type) {
-				case error:
-					v = r.(error).Error()
-				case runtime.Error:
-					v = r.(runtime.Error).Error()
-				case string:
-					v = r.(string)
-				}
-				log.Error("error on empty disk_queue,", v)
-			}
-		}
-	}()
-
-	if d.exitFlag == 1 {
+	d.RLock()
+	exiting := d.exitFlag == 1
+	d.RUnlock()
+	if exiting {
 		return errors.New("exiting")
 	}
 
 	log.Tracef("disk_queue(%s): emptying", d.name)
 
+	select {
+	case d.emptyChan <- 1:
+	case <-time.After(emptyWaitTimeout):
+		return errors.New("empty timeout waiting for ioLoop")
+	}
+
+	var result emptyResult
+	select {
+	case result = <-d.emptyResponseChan:
+	case <-time.After(emptyWaitTimeout):
+		return errors.New("empty timeout waiting for purge result")
+	}
+	if result.err != nil {
+		return result.err
+	}
+
+	// unlink stale files off the ioLoop path; writers race on the fresh
+	// head, which is kept
+	stale := result.stale
+	go func() {
+		for _, f := range stale {
+			if rmErr := os.Remove(f); rmErr != nil && !os.IsNotExist(rmErr) {
+				log.Errorf("diskqueue(%s) failed to remove data file [%s] - %s", d.name, f, rmErr)
+			}
+		}
+	}()
+	return nil
+}
+
+// emptyResult carries the purge outcome back from the ioLoop: the fresh
+// segment files to unlink (everything except metadata, which is persisted
+// with the fresh head instead of being removed).
+type emptyResult struct {
+	err   error
+	stale []string
+}
+
+// emptyWaitTimeout bounds how long Empty waits for the ioLoop to pick up
+// and finish a purge; generous enough to queue behind a full writeChan.
+const emptyWaitTimeout = 30 * time.Second
+
+// purge executes the queue purge in the ioLoop: snapshot the stale files,
+// jump to a fresh head above every segment on disk, and persist the new
+// metadata. Returned stale paths are unlinked asynchronously by Empty.
+func (d *DiskBasedQueue) purge() emptyResult {
 	// Snapshot the ACTUAL segment files on disk instead of synthesizing names
 	// from the in-memory counter: after metadata loss/resets across restarts,
 	// the directory commonly holds orphaned segments from earlier eras that no
 	// counter-based cleanup will ever reach.
-	d.Lock()
-	// find the highest segment actually on disk so the fresh head jumps past
-	// every file ever written — including orphans above the in-memory counter
-	// left behind by metadata loss across restarts — so segment numbers are
-	// never reused over stale bytes
 	maxSeg := d.writeSegmentNum
+	stale := make([]string, 0, 64)
+	metaName := path.Base(d.metaDataFileName())
 	if entries, err := os.ReadDir(d.dataPath); err == nil {
 		for _, e := range entries {
-			if seg, ok := segmentNumOf(e.Name()); ok && seg > maxSeg {
+			n := e.Name()
+			if seg, ok := segmentNumOf(n); ok && seg > maxSeg {
+				// jump past orphans above the in-memory counter too, so
+				// segment numbers are never reused over stale bytes
 				maxSeg = seg
 			}
+			if n == metaName || strings.HasPrefix(n, metaName+".") {
+				continue
+			}
+			stale = append(stale, path.Join(d.dataPath, n))
 		}
+	} else {
+		log.Errorf("diskqueue(%s): empty ReadDir(%v) failed: %v", d.name, d.dataPath, err)
 	}
+
 	// close open handles and jump to a fresh head with cleared positions
 	if d.readFile != nil {
 		_ = d.readFile.Close()
@@ -415,40 +463,14 @@ func (d *DiskBasedQueue) Empty() error {
 	d.nextReadPos = 0
 	d.depth = 0
 	d.needSync = true
-	metaFile := d.metaDataFileName()
-	dataPath := d.dataPath
-	d.Unlock()
 
-	// every file currently on disk is stale: the fresh head is a brand-new
-	// segment number nothing points at
-	stale := make([]string, 0, 64)
-	if entries, err := os.ReadDir(dataPath); err == nil {
-		metaName := path.Base(metaFile)
-		for _, e := range entries {
-			n := e.Name()
-			if n == metaName || strings.HasPrefix(n, metaName+".") {
-				continue
-			}
-			stale = append(stale, path.Join(dataPath, n))
-		}
-	} else {
-		log.Errorf("diskqueue(%s): empty ReadDir(%v) failed: %v", d.name, dataPath, err)
+	// persist the fresh head before reporting success so a crash right
+	// after Empty returns cannot resurrect the purged positions
+	if err := d.sync(); err != nil {
+		log.Errorf("diskqueue(%s) failed to sync after empty - %s", d.name, err)
 	}
-	log.Infof("diskqueue(%s): empty head=%v, %v files to unlink, dataPath=%v", d.name, d.writeSegmentNum, len(stale), dataPath)
-
-	// unlink outside the lock; writers race on the fresh head, which is kept
-	go func() {
-		for _, f := range stale {
-			if rmErr := os.Remove(f); rmErr != nil && !os.IsNotExist(rmErr) {
-				log.Errorf("diskqueue(%s) failed to remove data file [%s] - %s", d.name, f, rmErr)
-			}
-		}
-		if rmErr := os.Remove(metaFile); rmErr != nil && !os.IsNotExist(rmErr) {
-			log.Errorf("diskqueue(%s) failed to remove metadata file - %s", d.name, rmErr)
-		}
-	}()
-
-	return nil
+	log.Infof("diskqueue(%s): empty head=%v, %v files to unlink, dataPath=%v", d.name, d.writeSegmentNum, len(stale), d.dataPath)
+	return emptyResult{stale: stale}
 }
 
 // segmentNumOf parses "<zero-padded N>.dat[.zstd]" segment file names.
@@ -1035,6 +1057,9 @@ func (d *DiskBasedQueue) ioLoop() {
 			// readMoveForward sets needSync flag if a file is removed
 			d.readMoveForward()
 		case d.depthChan <- d.depth:
+		case <-d.emptyChan:
+			d.emptyResponseChan <- d.purge()
+			count = 0
 		case dataWrite := <-d.writeChan:
 			count++
 			d.writeResponseChan <- d.writeOne(dataWrite)

--- a/modules/queue/disk_queue/empty_concurrent_test.go
+++ b/modules/queue/disk_queue/empty_concurrent_test.go
@@ -1,0 +1,116 @@
+package queue
+
+import (
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/kv"
+)
+
+type concKV struct{ data map[string][]byte }
+
+func (m *concKV) Open() error  { return nil }
+func (m *concKV) Close() error { return nil }
+func (m *concKV) GetValue(b string, k []byte) ([]byte, error) {
+	if v, ok := m.data[string(k)]; ok {
+		return append([]byte(nil), v...), nil
+	}
+	return nil, nil
+}
+func (m *concKV) GetCompressedValue(b string, k []byte) ([]byte, error) { return m.GetValue(b, k) }
+func (m *concKV) AddValueCompress(b string, k, v []byte) error         { return m.AddValue(b, k, v) }
+func (m *concKV) AddValue(b string, k, v []byte) error {
+	m.data[string(k)] = append([]byte(nil), v...)
+	return nil
+}
+func (m *concKV) ExistsKey(b string, k []byte) (bool, error) {
+	_, ok := m.data[string(k)]
+	return ok, nil
+}
+func (m *concKV) DeleteKey(b string, k []byte) error {
+	delete(m.data, string(k))
+	return nil
+}
+
+func init() {
+	kv.Register("test-conc-kv", &concKV{data: map[string][]byte{}})
+}
+
+func TestEmptyUnderConcurrentTraffic(t *testing.T) {
+	global.Env().SystemConfig.PathConfig.Data = t.TempDir()
+	name := "test-empty-conc"
+	dataPath := GetDataPath(name)
+	_ = os.MkdirAll(dataPath, 0755)
+
+	cfg := &DiskQueueConfig{
+		MinMsgSize: 1, MaxMsgSize: 104857600,
+		MaxBytesPerFile: 1024, SyncEveryRecords: 1, SyncTimeoutInMS: 10,
+		WriteTimeoutInMS: 1000, EOFRetryDelayInMs: 100,
+		ReadChanBuffer: 10, WriteChanBuffer: 10,
+		PrepareFilesToRead: true,
+	}
+	d := NewDiskQueueByConfig(name, dataPath, cfg)
+	defer d.Close()
+
+	var stop int32
+	// producer
+	go func() {
+		for atomic.LoadInt32(&stop) == 0 {
+			d.Put([]byte("0123456789abcdef0123456789abcdef0123456789abcdef"))
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	// consumer
+	go func() {
+		for atomic.LoadInt32(&stop) == 0 {
+			select {
+			case <-d.ReadChan():
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+	}()
+
+	time.Sleep(2 * time.Second) // let segments accumulate
+
+	// simulate orphaned segments from earlier eras ABOVE the in-memory counter
+	// (metadata loss across restarts) — they must be purged too
+	for _, orphan := range []string{"000000200.dat", "000000201.dat", "000000201.dat.zstd"} {
+		if werr := os.WriteFile(filepath.Join(dataPath, orphan), []byte("orphan"), 0644); werr != nil {
+			t.Fatal(werr)
+		}
+	}
+
+	start := time.Now()
+	err := d.Empty()
+	elapsed := time.Since(start)
+	atomic.StoreInt32(&stop, 1)
+	if err != nil {
+		// dump goroutines to see where ioLoop / deleteAllFiles is stuck
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+		t.Fatalf("empty: %v (took %v)", err, elapsed)
+	}
+	t.Logf("empty took %v", elapsed)
+
+	time.Sleep(1 * time.Second)
+	files := 0
+	filepath.Walk(dataPath, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() {
+			files++
+		}
+		return nil
+	})
+	t.Logf("files after empty: %v", files)
+	if files > 3 {
+		t.Fatalf("expected stale segments gone, got %v files", files)
+	}
+	for _, orphan := range []string{"000000200.dat", "000000201.dat", "000000201.dat.zstd"} {
+		if _, err := os.Stat(filepath.Join(dataPath, orphan)); !os.IsNotExist(err) {
+			t.Fatalf("orphan %v survived empty", orphan)
+		}
+	}
+}

--- a/modules/queue/disk_queue/empty_test.go
+++ b/modules/queue/disk_queue/empty_test.go
@@ -1,0 +1,116 @@
+package queue
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/kv"
+)
+
+type memKV struct{ data map[string][]byte }
+
+func (m *memKV) Open() error                                     { return nil }
+func (m *memKV) Close() error                                    { return nil }
+func (m *memKV) GetValue(b string, k []byte) ([]byte, error) {
+	if v, ok := m.data[string(k)]; ok { return append([]byte(nil), v...), nil }
+	return nil, nil
+}
+func (m *memKV) GetCompressedValue(b string, k []byte) ([]byte, error) { return m.GetValue(b, k) }
+func (m *memKV) AddValueCompress(b string, k, v []byte) error          { return m.AddValue(b, k, v) }
+func (m *memKV) AddValue(b string, k, v []byte) error {
+	m.data[string(k)] = append([]byte(nil), v...)
+	return nil
+}
+func (m *memKV) ExistsKey(b string, k []byte) (bool, error) {
+	_, ok := m.data[string(k)]
+	return ok, nil
+}
+func (m *memKV) DeleteKey(b string, k []byte) error {
+	delete(m.data, string(k))
+	return nil
+}
+
+func init() {
+	kv.Register("test-mem-kv", &memKV{data: map[string][]byte{}})
+}
+
+func TestEmptyRemovesConsumedSegments(t *testing.T) {
+	global.Env().SystemConfig.PathConfig.Data = t.TempDir()
+	name := "test-empty-queue"
+	dataPath := GetDataPath(name)
+	_ = os.MkdirAll(dataPath, 0755)
+
+	cfg := &DiskQueueConfig{
+		MinMsgSize:       1,
+		MaxMsgSize:       104857600,
+		MaxBytesPerFile:  1024, // small segments: multiple files quickly
+		SyncEveryRecords: 1,
+		SyncTimeoutInMS:  10,
+		WriteTimeoutInMS: 1000,
+		EOFRetryDelayInMs: 100,
+		ReadChanBuffer:   10,
+		WriteChanBuffer:  10,
+	}
+	d := NewDiskQueueByConfig(name, dataPath, cfg)
+	defer d.Close()
+
+	// write enough records to roll several 1KB segments
+	for i := 0; i < 200; i++ {
+		res := d.Put([]byte("0123456789abcdef0123456789abcdef0123456789abcdef"))
+		if res.Error != nil {
+			t.Fatalf("put: %v", res.Error)
+		}
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	// consume everything so depth returns to 0 (consumed segments retained)
+	read := 0
+	for read < 200 {
+		select {
+		case <-d.ReadChan():
+			read++
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout consuming, read=%v", read)
+		}
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	filesBefore := 0
+	filepath.Walk(dataPath, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() {
+			filesBefore++
+		}
+		return nil
+	})
+	if filesBefore == 0 {
+		t.Fatal("no segment files before empty")
+	}
+
+	// the behavior under test: Empty drops ALL segment files, fast
+	start := time.Now()
+	if err := d.Empty(); err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Fatalf("empty took too long: %v", elapsed)
+	}
+
+	time.Sleep(500 * time.Millisecond) // async unlink
+	filesAfter := 0
+	filepath.Walk(dataPath, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() && filepath.Base(p) != "meta.dat" {
+			filesAfter++
+		}
+		return nil
+	})
+	if filesAfter != 0 {
+		t.Fatalf("expected 0 segment files after empty, got %v", filesAfter)
+	}
+	if d.Depth() != 0 {
+		t.Fatalf("expected depth 0, got %v", d.Depth())
+	}
+}

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -403,6 +403,24 @@ func (module *DiskQueue) Close(k string) error {
 	panic(errors.Errorf("queue [%v] not found", k))
 }
 
+// Empty drops all messages and consumed segment files of one queue while
+// keeping the queue registration and its consumers intact — the purge
+// behind POST /queue/:id/_empty. Not-found queues init on demand instead
+// of erroring (consistent with GetStorageSize).
+func (module *DiskQueue) Empty(k string) error {
+	q, ok := module.queues.Load(k)
+	if !ok {
+		if err := module.Init(k); err != nil {
+			return err
+		}
+		q, ok = module.queues.Load(k)
+		if !ok {
+			return errors.Errorf("queue [%v] not found", k)
+		}
+	}
+	return (q.(*DiskBasedQueue)).Empty()
+}
+
 func (module *DiskQueue) GetStorageSize(k string) uint64 {
 	q, ok := module.queues.Load(k)
 	if !ok {

--- a/plugins/queue/consumer/consumer.go
+++ b/plugins/queue/consumer/consumer.go
@@ -24,6 +24,7 @@
 package consumer
 
 import (
+	"context"
 	"fmt"
 	"infini.sh/framework/core/errors"
 	"infini.sh/framework/core/locker"
@@ -403,6 +404,12 @@ func (processor *QueueConsumerProcessor) HandleQueueConfig(qConfig *queue.QueueC
 			if err != nil {
 				panic(err)
 			}
+			// this spawn is a retry: give back one failure credit so a
+			// slice that recovers isn't latched out forever after a single
+			// failed worker (the counter previously only ever grew)
+			if ctx.Stats(sliceStats) > 0 {
+				ctx.Increment(sliceStats, -1)
+			}
 		}
 	}
 	return nil
@@ -672,7 +679,16 @@ READ_DOCS:
 			newCtx := pipeline.Context{}
 			newCtx.ParentContext = ctx
 			newCtx.Config = ctx.Config
-			newCtx.Context = ctx.Context
+			// Derive the sub-chain context from the owning pipeline's context
+			// (worker context as fallback): pipeline cancellation must reach
+			// the per-record loop inside the sub-chain, otherwise a stop only
+			// takes effect between fetches — with slow processors and deep
+			// queues that leaves a stopped pipeline draining for minutes.
+			subCtx, cancelSub := context.WithCancel(context.Background())
+			if parentContext != nil {
+				subCtx, cancelSub = context.WithCancel(parentContext.Context)
+			}
+			newCtx.Context = subCtx
 			newCtx.Data = ctx.CloneData()
 
 			_, err := newCtx.PutValue(processor.config.QueueField, qConfig.Name)
@@ -697,11 +713,17 @@ READ_DOCS:
 
 			//log.Error("start processing message:",len(messages),",",qConfig.Name)
 			err = processor.processors.Process(&newCtx)
+			cancelSub()
 			//log.Error("end processing message:",len(messages),",",qConfig.Name,",",err)
 			if err != nil {
 				panic(err)
 			}
-			offset = ctx1.NextOffset //TODO
+			// Only consume the batch when the pipeline is not stopping: a
+			// batch interrupted mid-processing keeps the previous offset so
+			// it is re-delivered next run (at-least-once).
+			if parentContext == nil || !parentContext.IsCanceled() {
+				offset = ctx1.NextOffset //TODO
+			}
 			messages = nil
 		} else {
 			EOF = true


### PR DESCRIPTION
## Summary

- new queue purge API (`POST /queue/:id/_empty`) with rewritten `Empty` semantics: the purge executes in the ioLoop, the head jumps past orphaned segments, stale files are unlinked asynchronously
- pipeline `startTask` no longer resurrects a STOPPING pipeline
- queue consumer derives its sub-chain context from the owning pipeline so cancellation interrupts mid-batch, keeps offsets on interrupted batches, and no longer latches a queue out after a single failed slice worker

Split from #416.

## Why the old `Empty` had to go

**1. Every call deadlocked — even on an idle queue.** The old chain:

```
Empty returns            requires  response received from emptyResponseChan
response sent (ioLoop)   requires  deleteAllFiles() return
deleteAllFiles returns   requires  skipToNextRWFile acquires d.Lock()
d.Lock() acquired        requires  Empty's RLock released (writer waits for all readers)
Empty's RLock released   requires  the deferred RUnlock to run
deferred RUnlock runs    requires  Empty to return        <- closes the cycle
```

The `defer { recover(); RUnlock() }` idiom protects against *panics* (e.g. the old `skipToNextRWFile` panics on close errors) — it cannot protect against *blocking*: a goroutine parked forever on `<-d.emptyResponseChan` never exits the function, so the defer never runs and the RLock is held forever. Worse, Go's RWMutex writer preference then queues every new `Put` behind `d.Lock()` (Puts have no timeout around RLock acquisition, only around the writeChan send), so a single `Empty()` call bricked the queue's ioLoop and write path until process restart.

**2. The purge was incomplete and unsafe across restarts.** `skipToNextRWFile(true)` deleted only file names synthesized from the in-memory counters (`readSegmentFileNum..writeSegmentNum`). After metadata loss/resets, the directory holds orphaned segments from earlier eras outside that range that no counter-based cleanup ever reaches (the ~14GB live case). A counter-derived fresh head can also *reuse* a segment number whose stale file still exists — `writeOne` opens `O_RDWR|O_CREATE` at pos 0 and the leftover tail bytes get framed as messages on read, i.e. data corruption.

**3. Synchronous unlink stalled the whole IO loop.** Thousands of `os.Remove` calls ran inline in the ioLoop; reads/writes/syncs were unserved for the duration.

## Design

`Empty` now holds **no lock while waiting**: it signals over `emptyChan`, and `purge()` executes inside the ioLoop — the single writer that owned the segment/position/file-handle state, race-free by construction (the long-tested execution model). It snapshots the actual directory (so orphans are purged too), jumps the head to `maxSegment+1` (so numbers are never reused over stale bytes), persists the fresh metadata *before* reporting success, and hands the stale list back for asynchronous unlinking by the caller. Puts simply queue behind the purge in `writeChan`, each bounded by `WriteTimeoutInMS`; both of `Empty`'s waits are capped by `emptyWaitTimeout`.

Note: an earlier iteration of this PR executed the purge under `d.Lock()` outside the ioLoop — that traded the deadlock for a data race (`-race` flagged ioLoop's unlocked `sync`/`persistMetaData` reads against `Empty`'s locked writes, and a Put-timeout leftover in `writeChan` could interleave `writeOne` with `Empty` closing `writeFile`). It was reverted to the ioLoop-execution model in 8db585d7.

## Test plan

- `go build ./modules/queue/... ./modules/pipeline/... ./plugins/queue/... ./core/queue/...`
- unit tests: `go test -race ./modules/queue/... ./plugins/queue/...` (new Empty sequential + concurrent tests; the concurrent test fails under `-race` on the d.Lock()-based iteration and passes on the final design)
- staged on a live agent + gateway + logpilot trio: purge verified against ~14GB of stale queue segments; pipeline stop/start now settles in seconds

🤖 Generated with ZCode
