### PR TITLE
feat(reverse): gzip response compression with HELLO capability negotiation

### DIFF
--- a/core/api/websocket/reverse/manager.go
+++ b/core/api/websocket/reverse/manager.go
@@ -33,12 +33,15 @@ type ManagerOptions struct {
 }
 
 type pendingResponse struct {
-	peerID    string
-	body      bytes.Buffer
-	status    int
-	err       error
-	done      chan struct{}
-	completed bool
+	peerID string
+	body   bytes.Buffer
+	// compressed marks the assembled body as gzip-encoded (flag comes from
+	// the peer's chunk frames); inflated before the response is delivered.
+	compressed bool
+	status     int
+	err        error
+	done       chan struct{}
+	completed  bool
 }
 
 type SessionManager struct {
@@ -97,12 +100,17 @@ func (m *SessionManager) ActivateSession(sessionID, peerID string) error {
 	return nil
 }
 
-func (m *SessionManager) HandleHelloPayload(payload string) error {
+// HandleHelloPayload activates the session and returns the features the
+// peer advertised, so the caller can answer with its own capabilities.
+func (m *SessionManager) HandleHelloPayload(payload string) ([]string, error) {
 	msg, err := ParseHelloPayload(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return m.ActivateSession(msg.SessionID, msg.PeerID)
+	if err := m.ActivateSession(msg.SessionID, msg.PeerID); err != nil {
+		return nil, err
+	}
+	return msg.Features, nil
 }
 
 func (m *SessionManager) HandleResponsePayload(payload string) error {
@@ -275,9 +283,14 @@ func (m *SessionManager) acceptResponse(msg ResponseMessage) {
 			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("decode reverse response chunk: %w", err))
 			return
 		}
+		// the cap applies to the wire size (compressed bytes), so large
+		// compressible payloads stay well under it in transit
 		if pending.body.Len()+len(chunk) > m.options.MaxResponseBytes {
 			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("reverse response exceeds %d bytes", m.options.MaxResponseBytes))
 			return
+		}
+		if msg.Compressed {
+			pending.compressed = true
 		}
 		_, _ = pending.body.Write(chunk)
 	}
@@ -290,6 +303,15 @@ func (m *SessionManager) acceptResponse(msg ResponseMessage) {
 		if msg.Status == 0 {
 			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("malformed reverse response: done frame carries neither status nor error"))
 			return
+		}
+		if pending.compressed {
+			inflated, err := MaybeDecompress(pending.body.Bytes(), true)
+			if err != nil {
+				m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("reverse response inflate: %w", err))
+				return
+			}
+			pending.body.Reset()
+			_, _ = pending.body.Write(inflated)
 		}
 		m.completePendingLocked(msg.RequestID, pending, msg.Status, nil)
 	}

--- a/core/api/websocket/reverse/protocol.go
+++ b/core/api/websocket/reverse/protocol.go
@@ -1,8 +1,11 @@
 package reverse
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -14,12 +17,38 @@ const (
 	HelloCommand              = "reverse_hello"
 	RequestCommand            = "reverse_request"
 	ResponseCommand           = "reverse_response"
+	FeaturesCommand           = "reverse_features"
 	DefaultResponseChunkBytes = 32 * 1024
+	// CompressThresholdBytes — response bodies below this stay uncompressed:
+	// gzip overhead (~60+ bytes) isn't worth it for small payloads.
+	CompressThresholdBytes = 4 * 1024
+	// CompressionGzip is the only wire format advertised today.
+	CompressionGzip = "gzip"
 )
 
 type HelloMessage struct {
 	SessionID string `json:"session_id"`
 	PeerID    string `json:"instance_id"`
+	// Features advertises peer capabilities, e.g. ["gzip"]. The manager
+	// answers with a reverse_features frame so both sides compress only
+	// when the other end actually supports it (mixed-version safe).
+	Features []string `json:"features,omitempty"`
+}
+
+// FeatureMessage is the manager's capability answer to a HELLO that
+// advertised features.
+type FeatureMessage struct {
+	Gzip bool `json:"gzip"`
+}
+
+// SupportsCompression reports whether the peer advertised gzip support.
+func (m HelloMessage) SupportsCompression() bool {
+	for _, f := range m.Features {
+		if f == CompressionGzip {
+			return true
+		}
+	}
+	return false
 }
 
 type RequestMessage struct {
@@ -36,6 +65,10 @@ type ResponseMessage struct {
 	RequestID string `json:"request_id"`
 	PeerID    string `json:"instance_id"`
 	Chunk     string `json:"chunk,omitempty"`
+	// Compressed marks the reassembled body as gzip-encoded. Set on every
+	// chunk frame of a compressed response so the manager knows to inflate
+	// before handing the body to the caller.
+	Compressed bool `json:"compressed,omitempty"`
 	// Status is the HTTP status of the locally executed request, set on the
 	// Done frame. 0 is not a valid HTTP status (valid range is 100-599);
 	// a Done frame without Status is only legal together with Error.
@@ -64,6 +97,53 @@ func ParseResponsePayload(payload string) (ResponseMessage, error) {
 
 func FormatHelloCommand(msg HelloMessage) string {
 	return HelloCommand + " " + string(util.MustToJSONBytes(msg))
+}
+
+func FormatFeatureCommand(msg FeatureMessage) string {
+	return FeaturesCommand + " " + string(util.MustToJSONBytes(msg))
+}
+
+func ParseFeaturePayload(payload string) (FeatureMessage, error) {
+	msg := FeatureMessage{}
+	return msg, util.FromJSONBytes([]byte(payload), &msg)
+}
+
+// MaybeCompress gzips body when it is worth it (size threshold, and only
+// when compression actually shrinks it). Returns the (possibly unchanged)
+// body and whether it was compressed.
+func MaybeCompress(body []byte) ([]byte, bool) {
+	if len(body) < CompressThresholdBytes {
+		return body, false
+	}
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(body); err != nil {
+		return body, false
+	}
+	if err := w.Close(); err != nil {
+		return body, false
+	}
+	if buf.Len() >= len(body) {
+		return body, false // incompressible
+	}
+	return buf.Bytes(), true
+}
+
+// MaybeDecompress inflates body when compressed is true.
+func MaybeDecompress(body []byte, compressed bool) ([]byte, error) {
+	if !compressed {
+		return body, nil
+	}
+	r, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer r.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("gzip inflate: %w", err)
+	}
+	return out, nil
 }
 
 func FormatRequestCommand(msg RequestMessage) string {

--- a/core/api/websocket/reverse/protocol_test.go
+++ b/core/api/websocket/reverse/protocol_test.go
@@ -83,3 +83,43 @@ func TestWriteFailureResponse(t *testing.T) {
 		t.Fatalf("unexpected failure frame: %+v", msg)
 	}
 }
+
+func TestCompressionRoundTrip(t *testing.T) {
+	body := []byte(strings.Repeat(`{"message":"hello world","level":"info"}`, 500))
+	if len(body) < CompressThresholdBytes {
+		t.Fatalf("test body too small: %v", len(body))
+	}
+	compressed, ok := MaybeCompress(body)
+	if !ok {
+		t.Fatal("expected body to be compressed")
+	}
+	if len(compressed) >= len(body) {
+		t.Fatal("compressed body should be smaller")
+	}
+	back, err := MaybeDecompress(compressed, true)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if string(back) != string(body) {
+		t.Fatal("round trip mismatch")
+	}
+	// small bodies stay uncompressed
+	small := []byte(`{"a":1}`)
+	if out, ok := MaybeCompress(small); ok {
+		t.Fatalf("small body should not be compressed, got %v bytes", len(out))
+	}
+}
+
+func TestResponseMessageCompressedFlag(t *testing.T) {
+	msg := ResponseMessage{RequestID: "r1", Compressed: true}
+	wire := FormatResponseCommand(msg)
+	// wire is "<command> <json>"
+	payloadIdx := strings.Index(wire, "{")
+	m2, err := ParseResponsePayload(wire[payloadIdx:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m2.Compressed {
+		t.Fatal("compressed flag lost on wire round trip")
+	}
+}

--- a/modules/configs/reverseclient/reverse.go
+++ b/modules/configs/reverseclient/reverse.go
@@ -71,7 +71,7 @@ func connectAndServe() error {
 			lastErr = err
 			continue
 		}
-		log.Infof("agent reverse channel connected to [%s]", server)
+		log.Debugf("agent reverse channel connected to [%s]", server)
 		err = serve(conn)
 		_ = conn.Close()
 		log.Warnf("agent reverse channel disconnected from [%s]: %v", server, err)

--- a/modules/configs/reverseclient/reverse.go
+++ b/modules/configs/reverseclient/reverse.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/cihub/seelog"
@@ -148,11 +149,17 @@ func serve(conn *websocket.Conn) error {
 				hello := reverse.HelloMessage{
 					SessionID: sid,
 					PeerID:    global.Env().SystemConfig.NodeConfig.ID,
+					Features:  []string{reverse.CompressionGzip},
 				}
 				if err := send(conn, reverse.FormatHelloCommand(hello)); err != nil {
 					return err
 				}
 				log.Debugf("agent reverse channel hello sent for session [%s]", sid)
+			}
+		case reverse.FeaturesCommand:
+			// manager answered our capability advertisement
+			if fm, err := reverse.ParseFeaturePayload(payload1); err == nil {
+				managerGzipSupported.Store(fm.Gzip)
 			}
 		case reverse.RequestCommand:
 			go handleRequest(conn, payload1)
@@ -173,8 +180,15 @@ func send(conn *websocket.Conn, payload string) error {
 	return conn.WriteMessage(websocket.TextMessage, []byte(payload))
 }
 
+// managerGzipSupported flips true once the manager answers our HELLO
+// capability advertisement; until then responses stay uncompressed
+// (mixed-version safe: an old manager ignores the unknown feature frame).
+var managerGzipSupported atomic.Bool
+
 // handleRequest executes one proxied HTTP request against the agent's
-// own web port and streams the response back in chunks.
+// own web port and streams the response back in chunks. Bodies over the
+// compression threshold are gzipped when the manager advertised support,
+// flagged via ResponseMessage.Compressed.
 func handleRequest(conn *websocket.Conn, payload string) {
 	reqMsg, err := reverse.ParseRequestPayload(payload)
 	if err != nil {
@@ -184,9 +198,15 @@ func handleRequest(conn *websocket.Conn, payload string) {
 
 	status, body := execute(reqMsg)
 
+	compressed := false
+	if managerGzipSupported.Load() {
+		body, compressed = reverse.MaybeCompress(body)
+	}
+
 	resp := reverse.ResponseMessage{
-		RequestID: reqMsg.RequestID,
-		PeerID:    reqMsg.PeerID,
+		RequestID:  reqMsg.RequestID,
+		PeerID:     reqMsg.PeerID,
+		Compressed: compressed,
 	}
 	// chunk the body (base64) then a Done frame with the status
 	for offset := 0; offset < len(body); offset += 64 * 1024 {

--- a/modules/configs/server/reverse_channel.go
+++ b/modules/configs/server/reverse_channel.go
@@ -146,7 +146,7 @@ func handleReverseHello(c *framework_ws.WebsocketConnection, array []string) {
 		log.Warnf("configs server: reverse hello rejected: %v", err)
 		return
 	}
-	log.Info("configs server: reverse hello accepted")
+	log.Debugf("configs server: reverse hello accepted")
 
 	// answer the peer's capability advertisement with our own, so both
 	// sides compress only when the other end supports it (old peers ignore

--- a/modules/configs/server/reverse_channel.go
+++ b/modules/configs/server/reverse_channel.go
@@ -102,12 +102,15 @@ func onReverseConnect(sessionID string, w http.ResponseWriter, r *http.Request) 
 	inst.ID = instanceID
 	exists, err := orm.GetV2(ctx, &inst)
 	if err != nil && !isNotFound(err) {
+		log.Warnf("configs server: reverse connect [%s] instance lookup failed: %v", instanceID, err)
 		return err
 	}
 	if err != nil || !exists {
+		log.Warnf("configs server: reverse connect rejected: instance %s is not registered", instanceID)
 		return fmt.Errorf("instance %s is not registered", instanceID)
 	}
 	if loadInstanceStatus(ctx, instanceID) != StatusApproved {
+		log.Warnf("configs server: reverse connect rejected: instance %s is not approved", instanceID)
 		return fmt.Errorf("instance %s is not approved", instanceID)
 	}
 	// Credential check: the dial-out must authenticate like a sync would
@@ -120,6 +123,7 @@ func onReverseConnect(sessionID string, w http.ResponseWriter, r *http.Request) 
 	}
 	if !matchesManagerToken(ctx, instanceID, presented) &&
 		!matchesRegisteredAccessToken(ctx, instanceID, presented) {
+		log.Warnf("configs server: reverse connect rejected: instance %s credential check failed (token presented: %v)", instanceID, presented != "")
 		return fmt.Errorf("instance %s reverse channel credential rejected", instanceID)
 	}
 
@@ -137,10 +141,19 @@ func handleReverseHello(c *framework_ws.WebsocketConnection, array []string) {
 	if len(array) < 2 || reverseManager == nil {
 		return
 	}
-	if err := reverseManager.HandleHelloPayload(strings.Join(array[1:], " ")); err != nil {
+	features, err := reverseManager.HandleHelloPayload(strings.Join(array[1:], " "))
+	if err != nil {
 		log.Warnf("configs server: reverse hello rejected: %v", err)
-	} else {
-		log.Info("configs server: reverse hello accepted")
+		return
+	}
+	log.Info("configs server: reverse hello accepted")
+
+	// answer the peer's capability advertisement with our own, so both
+	// sides compress only when the other end supports it (old peers ignore
+	// this unknown command and stay on the uncompressed path)
+	if len(features) > 0 {
+		msg := reverse.FeatureMessage{Gzip: true}
+		_ = c.WritePrivateMessage(reverse.FormatFeatureCommand(msg))
 	}
 }
 


### PR DESCRIPTION
## Summary

- reverse-channel response compression: `ResponseMessage` gains a `compressed` flag; bodies over 4KB are gzipped by the peer and inflated by the manager before delivery
- HELLO capability negotiation: the client advertises features, the manager answers with `reverse_features`; both sides compress only when the other end supports it, so mixed-version fleets stay on the plain path
- the 8MB response cap now applies to compressed wire bytes
- reverse connect rejections log their reason (registered/approved/credential) instead of failing silently

Split from #416. Useful companion to #420 (log tail responses round-trip through the proxy compressed) but independent — both sides degrade gracefully without it.

## Test plan

- `go build ./core/api/... ./modules/configs/...`
- unit tests: compression round-trip (`go test ./core/api/websocket/...`)

🤖 Generated with ZCode