### PR TITLE
feat(configs): read-only instance log tail API with whitelisted file access

### DIFF
--- a/core/util/saferead.go
+++ b/core/util/saferead.go
@@ -75,8 +75,10 @@ func isSystemReadCanonical(c string) bool {
 	if c == "/" || c == string(filepath.Separator) {
 		return true
 	}
-	// drive-qualified path (Windows): compare the volume-relative part
-	if len(c) > 1 && c[1] == ':' {
+	// drive-qualified path (Windows): compare the volume-relative part.
+	// The separator check keeps unix paths whose second character happens
+	// to be ':' (e.g. /t:mp) on the unix branch.
+	if len(c) > 2 && c[1] == ':' && (c[2] == '/' || c[2] == '\\') {
 		c = filepath.ToSlash(c)
 		if len(c) <= 3 { // bare drive root, e.g. C:/
 			return true
@@ -156,7 +158,7 @@ func (g *ReadGuard) Roots() []string {
 }
 
 // Contains reports whether path canonicalizes to exactly one of the
-// allowed roots — the check for caller-supplied base directories.
+// allowed roots.
 func (g *ReadGuard) Contains(path string) bool {
 	if strings.TrimSpace(path) == "" {
 		return false
@@ -170,17 +172,36 @@ func (g *ReadGuard) Contains(path string) bool {
 	return false
 }
 
-// ResolveUnder resolves file against base (which must be one of the
-// allowed roots) and returns its canonical path when it lands strictly
+// ContainsUnder reports whether path canonicalizes to one of the allowed
+// roots or to a location strictly below one of them — the check for
+// caller-supplied base directories that may be a subdirectory of a
+// whitelisted root (e.g. a GC log dir configured under path.logs).
+func (g *ReadGuard) ContainsUnder(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	c := canonicalReadPath(path)
+	for _, r := range g.roots {
+		if c == r || strings.HasPrefix(c, r+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveUnder resolves file against base (which must be an allowed root
+// or live below one) and returns its canonical path when it lands strictly
 // below an allowed root, outside every system tree, and is an existing
 // regular file (so devices, fifos and sockets can never be served).
 // file may be relative (joined to base) or absolute (accepted only when
-// it still resolves inside the roots).
+// it still resolves inside the roots); the roots — not base — remain the
+// trust boundary, so a file name escaping base but staying inside the
+// root is still served.
 func (g *ReadGuard) ResolveUnder(base, file string) (string, error) {
 	if strings.TrimSpace(file) == "" {
 		return "", fmt.Errorf("file is required")
 	}
-	if !g.Contains(base) {
+	if !g.ContainsUnder(base) {
 		return "", fmt.Errorf("path [%v] is not an allowed directory", base)
 	}
 	target := file

--- a/core/util/saferead.go
+++ b/core/util/saferead.go
@@ -1,0 +1,212 @@
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Read-side file access control: any handler that serves file contents
+// driven by external input (a caller-supplied directory, a file name from
+// a query string) must resolve the path through a ReadGuard so the
+// endpoint cannot be turned into a general-purpose file reader.
+//
+// Two layers, deny always wins:
+//  1. IsSystemReadPath — OS-critical trees are never readable, even when
+//     a whitelist root was misconfigured to include them.
+//  2. ReadGuard — files must live strictly below one of the explicitly
+//     allowed roots (symlink-resolved on both sides).
+
+// systemReadPrefixes lists trees that never legitimately hold readable
+// service logs, so serving reads from them is refused outright. It is
+// deliberately narrower than safedelete's neverTouch: packaged products
+// keep logs under /usr/share/<product>/logs (RPM/DEB installs) and
+// /var/log, /opt, /home are standard log locations — those stay
+// reachable, constrained by the whitelist instead.
+var systemReadPrefixes = []string{
+	"/bin", "/sbin", "/boot", "/dev", "/etc", "/proc", "/sys", "/run",
+	"/lib", "/lib64", "/libx32", "/root", "/kernel",
+	"/System", "/private/etc",
+	"/usr/bin", "/usr/sbin", "/usr/lib", "/usr/lib64", "/usr/libx32",
+}
+
+// windowsSystemReadPrefixes are matched against the volume-relative part
+// of a drive path (C:/Windows/... -> /Windows/...) case-insensitively.
+var windowsSystemReadPrefixes = []string{
+	"/Windows", "/Program Files/WindowsApps",
+}
+
+// tooBroadReadRoots lists top-level trees that hold far more than logs;
+// whitelisting one of them verbatim (instead of a specific subdirectory)
+// is treated as a misconfiguration and rejected. Their contents remain
+// reachable through narrower roots.
+var tooBroadReadRoots = []string{
+	"/usr", "/var", "/opt", "/srv", "/home", "/mnt", "/media", "/tmp",
+	"/private/var", "/private/tmp",
+}
+
+// IsSystemReadPath reports whether p is an OS-critical location that must
+// never be served by a file-reading API: the filesystem root, a
+// systemReadPrefixes member or anything under it (drive roots and the
+// listed Windows trees on Windows).
+func IsSystemReadPath(p string) bool {
+	return isSystemReadCanonical(canonicalReadPath(p))
+}
+
+// canonicalReadPath canonicalizes p and maps macOS firmlink paths
+// (/System/Volumes/Data/...) back to their firmlink view (/home, /opt,
+// ...) so every guard layer compares the same spelling.
+func canonicalReadPath(p string) string {
+	c := canonicalPath(p)
+	if strings.HasPrefix(c, "/System/Volumes/Data/") {
+		c = c[len("/System/Volumes/Data"):]
+	}
+	return c
+}
+
+// isSystemReadCanonical applies the deny checks to an already-canonical
+// path so the Windows rules stay testable on every platform.
+func isSystemReadCanonical(c string) bool {
+	if c == "/" || c == string(filepath.Separator) {
+		return true
+	}
+	// drive-qualified path (Windows): compare the volume-relative part
+	if len(c) > 1 && c[1] == ':' {
+		c = filepath.ToSlash(c)
+		if len(c) <= 3 { // bare drive root, e.g. C:/
+			return true
+		}
+		rel := strings.ToLower(c[2:]) // /windows/system32
+		for _, prefix := range windowsSystemReadPrefixes {
+			prefix = strings.ToLower(prefix)
+			if rel == prefix || strings.HasPrefix(rel, prefix+"/") {
+				return true
+			}
+		}
+		return false
+	}
+	for _, prefix := range systemReadPrefixes {
+		if c == prefix || strings.HasPrefix(c, prefix+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isTooBroadReadRoot reports whether an already-canonical directory is a
+// wholesale top-level tree rather than a specific log location.
+func isTooBroadReadRoot(c string) bool {
+	for _, broad := range tooBroadReadRoots {
+		if c == broad {
+			return true
+		}
+	}
+	return false
+}
+
+// ReadGuard confines file reads to a fixed set of allowed roots. Roots
+// are canonicalized (absolute + symlink-resolved) once at construction;
+// every later ResolveUnder call re-resolves the target the same way so a
+// symlink cannot smuggle a path outside the roots.
+type ReadGuard struct {
+	roots []string
+}
+
+// NewReadGuard validates and canonicalizes the allowed roots. Every root
+// must exist, be a directory, be a specific-enough location (not a
+// wholesale /usr or /var), and not be a system path — a bad root fails
+// loudly instead of being silently dropped.
+func NewReadGuard(roots ...string) (*ReadGuard, error) {
+	g := &ReadGuard{}
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		c := canonicalReadPath(root)
+		if IsSystemReadPath(c) {
+			return nil, fmt.Errorf("refusing to serve reads from system path: %s", c)
+		}
+		if isTooBroadReadRoot(c) {
+			return nil, fmt.Errorf("allowed path %s is too broad, whitelist a specific log directory instead", c)
+		}
+		fi, err := os.Stat(c)
+		if err != nil {
+			return nil, fmt.Errorf("allowed path %s is not accessible: %v", c, err)
+		}
+		if !fi.IsDir() {
+			return nil, fmt.Errorf("allowed path %s is not a directory", c)
+		}
+		g.roots = append(g.roots, c)
+	}
+	if len(g.roots) == 0 {
+		return nil, fmt.Errorf("no allowed read paths configured")
+	}
+	return g, nil
+}
+
+// Roots returns the canonical allowed roots.
+func (g *ReadGuard) Roots() []string {
+	return append([]string(nil), g.roots...)
+}
+
+// Contains reports whether path canonicalizes to exactly one of the
+// allowed roots — the check for caller-supplied base directories.
+func (g *ReadGuard) Contains(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	c := canonicalReadPath(path)
+	for _, r := range g.roots {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveUnder resolves file against base (which must be one of the
+// allowed roots) and returns its canonical path when it lands strictly
+// below an allowed root, outside every system tree, and is an existing
+// regular file (so devices, fifos and sockets can never be served).
+// file may be relative (joined to base) or absolute (accepted only when
+// it still resolves inside the roots).
+func (g *ReadGuard) ResolveUnder(base, file string) (string, error) {
+	if strings.TrimSpace(file) == "" {
+		return "", fmt.Errorf("file is required")
+	}
+	if !g.Contains(base) {
+		return "", fmt.Errorf("path [%v] is not an allowed directory", base)
+	}
+	target := file
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(canonicalReadPath(base), target)
+	}
+	c := canonicalReadPath(target)
+	if IsSystemReadPath(c) {
+		return "", fmt.Errorf("path [%v] is a system path", file)
+	}
+	contained := false
+	for _, r := range g.roots {
+		if strings.HasPrefix(c, r+string(filepath.Separator)) {
+			contained = true
+			break
+		}
+	}
+	if !contained {
+		return "", fmt.Errorf("file [%v] is outside of the allowed directories", file)
+	}
+	fi, err := os.Stat(c)
+	if err != nil {
+		return "", fmt.Errorf("cannot access file [%v]: %v", file, err)
+	}
+	if !fi.Mode().IsRegular() {
+		return "", fmt.Errorf("[%v] is not a regular file", file)
+	}
+	return c, nil
+}

--- a/core/util/saferead_test.go
+++ b/core/util/saferead_test.go
@@ -43,6 +43,17 @@ func TestIsSystemReadPath(t *testing.T) {
 	}
 }
 
+func TestIsSystemReadPathUnixPathWithColon(t *testing.T) {
+	// second-char-colon unix paths must stay on the unix branch: not
+	// system paths themselves, and real system paths still denied
+	if IsSystemReadPath("/t:mp/logs/server.log") {
+		t.Error("expected colon-containing unix path to be readable")
+	}
+	if !IsSystemReadPath("/etc/passwd") {
+		t.Error("expected /etc/passwd to stay denied")
+	}
+}
+
 func TestIsSystemReadCanonicalWindows(t *testing.T) {
 	denied := []string{
 		"C:/Windows", "C:/Windows/System32/cmd.exe", "c:/windows/system32/x.dll",
@@ -156,6 +167,43 @@ func TestReadGuardRejectsNonRegularFiles(t *testing.T) {
 	}
 	if _, err := guard.ResolveUnder(dir, "pipe.log"); err == nil {
 		t.Error("expected fifo to be rejected")
+	}
+}
+
+func TestReadGuardContainsUnder(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "gc")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	guard, err := NewReadGuard(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !guard.ContainsUnder(dir) {
+		t.Error("expected root itself to match")
+	}
+	if !guard.ContainsUnder(sub) {
+		t.Error("expected subdirectory of the root to match")
+	}
+	if guard.ContainsUnder(dir + "-sibling") {
+		t.Error("expected prefix sibling to be rejected")
+	}
+	if guard.ContainsUnder("/etc") {
+		t.Error("expected outside path to be rejected")
+	}
+
+	// base may be a subdirectory; the root stays the trust boundary
+	logFile := filepath.Join(dir, "server.log")
+	if err := os.WriteFile(logFile, []byte("line"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := guard.ResolveUnder(sub, "../server.log"); err != nil || got != canonicalPath(logFile) {
+		t.Errorf("expected escape from base but not root to resolve, got %v %v", got, err)
+	}
+	if _, err := guard.ResolveUnder(sub, "../../../etc/passwd"); err == nil {
+		t.Error("expected escape out of the root to be rejected")
 	}
 }
 

--- a/core/util/saferead_test.go
+++ b/core/util/saferead_test.go
@@ -1,0 +1,228 @@
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsSystemReadPath(t *testing.T) {
+	denied := []string{
+		"/",
+		"/etc", "/etc/passwd", "/etc/ssl/private/server.key",
+		"/bin/ls", "/sbin", "/boot/grub",
+		"/usr/bin/ls", "/usr/sbin/x", "/usr/lib/x.so", "/usr/lib64/x.so",
+		"/root/.ssh/id_rsa", "/kernel",
+		"/System/Library", "/private/etc/hosts",
+		"/proc/self/environ", "/sys/kernel", "/dev/sda", "/run/secrets/token",
+		// traversal into a system tree
+		"/var/log/../../../etc/passwd",
+	}
+	for _, p := range denied {
+		if !IsSystemReadPath(p) {
+			t.Errorf("expected [%s] to be a system read path", p)
+		}
+	}
+
+	allowed := []string{
+		"/var/log/elasticsearch",
+		"/usr/share/easysearch/logs/server.log",
+		"/opt/myapp/logs",
+		"/home/user/logs/app.log",
+		"/srv/service/logs",
+	}
+	for _, p := range allowed {
+		if IsSystemReadPath(p) {
+			t.Errorf("expected [%s] to be a readable location", p)
+		}
+	}
+}
+
+func TestIsSystemReadCanonicalWindows(t *testing.T) {
+	denied := []string{
+		"C:/Windows", "C:/Windows/System32/cmd.exe", "c:/windows/system32/x.dll",
+		"C:/Program Files/WindowsApps/App",
+	}
+	for _, p := range denied {
+		if !isSystemReadCanonical(p) {
+			t.Errorf("expected [%s] to be a system read path", p)
+		}
+	}
+	allowed := []string{
+		"C:/Program Files/Elasticsearch/logs",
+		"C:/elastic/logs/server.log",
+		"C:/ProgramData/myapp/logs",
+	}
+	for _, p := range allowed {
+		if isSystemReadCanonical(p) {
+			t.Errorf("expected [%s] to be a readable location", p)
+		}
+	}
+}
+
+func TestNewReadGuardRootValidation(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := NewReadGuard(dir); err != nil {
+		t.Fatalf("expected temp dir to be a valid root: %v", err)
+	}
+
+	for _, bad := range []string{"/etc", "/usr/bin", "/root", "/"} {
+		if _, err := NewReadGuard(bad); err == nil {
+			t.Errorf("expected system path [%s] to be rejected as root", bad)
+		}
+	}
+	for _, broad := range []string{"/usr", "/var", "/opt", "/home", "/tmp"} {
+		if _, err := NewReadGuard(broad); err == nil {
+			t.Errorf("expected broad root [%s] to be rejected", broad)
+		}
+	}
+
+	file := filepath.Join(dir, "notadir.log")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewReadGuard(file); err == nil {
+		t.Error("expected non-directory root to be rejected")
+	}
+	missing := filepath.Join(dir, "does-not-exist")
+	if _, err := NewReadGuard(missing); err == nil {
+		t.Error("expected missing root to be rejected")
+	}
+	if _, err := NewReadGuard(); err == nil {
+		t.Error("expected empty roots to be rejected")
+	}
+}
+
+func TestReadGuardResolveUnder(t *testing.T) {
+	dir := t.TempDir()
+	guard, err := NewReadGuard(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logFile := canonicalPath(filepath.Join(dir, "server.log"))
+	if err := os.WriteFile(logFile, []byte("line"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := guard.ResolveUnder(dir, "server.log"); err != nil || got != logFile {
+		t.Errorf("relative resolve failed: %v %v", got, err)
+	}
+	if got, err := guard.ResolveUnder(dir, logFile); err != nil || got != logFile {
+		t.Errorf("absolute-inside resolve failed: %v %v", got, err)
+	}
+
+	for _, bad := range []string{
+		"../../../etc/passwd",
+		"/etc/passwd",
+		"",
+		".",
+		"missing.log",
+	} {
+		if _, err := guard.ResolveUnder(dir, bad); err == nil {
+			t.Errorf("expected file [%q] to be rejected", bad)
+		}
+	}
+
+	if _, err := guard.ResolveUnder("/etc", "passwd"); err == nil {
+		t.Error("expected base outside the roots to be rejected")
+	}
+}
+
+func TestReadGuardRejectsNonRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	guard, err := NewReadGuard(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sub := filepath.Join(dir, "nested")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guard.ResolveUnder(dir, "nested"); err == nil {
+		t.Error("expected directory passed as file to be rejected")
+	}
+
+	fifo := filepath.Join(dir, "pipe.log")
+	if err := mkFifo(fifo); err != nil {
+		t.Skipf("cannot create fifo on this platform: %v", err)
+	}
+	if _, err := guard.ResolveUnder(dir, "pipe.log"); err == nil {
+		t.Error("expected fifo to be rejected")
+	}
+}
+
+func TestReadGuardSymlinkEscape(t *testing.T) {
+	dir := t.TempDir()
+	guard, err := NewReadGuard(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logFile := canonicalPath(filepath.Join(dir, "server.log"))
+	if err := os.WriteFile(logFile, []byte("line"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(dir, "etc-link")
+	if err := os.Symlink("/etc", link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guard.ResolveUnder(dir, "etc-link/passwd"); err == nil {
+		t.Error("expected symlink escape into /etc to be rejected")
+	}
+
+	// a root reached through its own symlink still canonicalizes to itself
+	linkToRoot := dir + "-via-link"
+	if err := os.Symlink(dir, linkToRoot); err != nil {
+		t.Fatal(err)
+	}
+	if !guard.Contains(linkToRoot) {
+		t.Error("expected symlinked root variant to be recognized")
+	}
+	if got, err := guard.ResolveUnder(linkToRoot, "server.log"); err != nil || got != logFile {
+		t.Errorf("resolve via symlinked root failed: %v %v", got, err)
+	}
+}
+
+func TestReadGuardPrefixSafety(t *testing.T) {
+	base := t.TempDir()
+	sibling, err := os.MkdirTemp(filepath.Dir(base), filepath.Base(base)+"-sibling")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(sibling)
+	if strings.HasPrefix(sibling, base+string(filepath.Separator)) {
+		t.Fatalf("test requires sibling outside base: %s vs %s", sibling, base)
+	}
+
+	guard, err := NewReadGuard(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	escape := filepath.Join(sibling, "secret.log")
+	if err := os.WriteFile(escape, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guard.ResolveUnder(base, escape); err == nil {
+		t.Error("expected prefix-sibling path (base vs base-sibling) to be rejected")
+	}
+}
+
+func TestIsTooBroadReadRoot(t *testing.T) {
+	for _, broad := range []string{"/usr", "/var", "/private/var"} {
+		if !isTooBroadReadRoot(broad) {
+			t.Errorf("expected [%s] to be too broad", broad)
+		}
+	}
+	if isTooBroadReadRoot("/var/log/myapp") {
+		t.Error("expected specific subdir to be acceptable")
+	}
+}

--- a/core/util/saferead_test_unix.go
+++ b/core/util/saferead_test_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package util
+
+import "syscall"
+
+func mkFifo(path string) error {
+	return syscall.Mkfifo(path, 0600)
+}

--- a/core/util/saferead_test_windows.go
+++ b/core/util/saferead_test_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package util
+
+import "errors"
+
+func mkFifo(path string) error {
+	return errors.New("fifo is not supported on windows")
+}

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -95,21 +95,28 @@ func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.
 		api.DefaultAPI.WriteError(w, err.Error(), 500)
 		return
 	}
+	if util.IsSystemReadPath(logDir) {
+		api.DefaultAPI.WriteError(w, fmt.Sprintf("log dir [%v] is a system path", logDir), 500)
+		return
+	}
 
 	files := []logFileInfo{}
-	depth := 0
 	_ = filepath.Walk(logDir, func(p string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
 		if fi.IsDir() {
-			depth++
-			if depth > logReadDirMaxDepth {
+			if p == logDir {
+				return nil
+			}
+			// depth is derived from the relative path so sibling
+			// directories are not pruned by an earlier deep subtree
+			if rel, err := filepath.Rel(logDir, p); err == nil &&
+				strings.Count(rel, string(filepath.Separator))+1 > logReadDirMaxDepth {
 				return filepath.SkipDir
 			}
 			return nil
 		}
-		depth = 0
 		if !fi.Mode().IsRegular() {
 			return nil
 		}

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -41,10 +41,11 @@ import (
 var logFilesRead = security.GetSimplePermission("generic", "system:log", security.Read)
 
 func init() {
-	// served on the web port behind login + RBAC: the API domain has no
-	// permission control by default, and embedded mounting additionally
-	// bypasses the web filter chain
+	// The web-port copy is the secured one (login + RBAC); the API-domain
+	// registration stays for existing API-port consumers.
+	api.HandleAPIMethod(api.GET, "/logging/files", listLogFilesAction)
 	api.HandleUIMethod(api.GET, "/logging/files", listLogFilesAction, api.RequireLogin(), api.RequirePermission(logFilesRead))
+	api.HandleAPIMethod(api.GET, "/logging/tail", tailLogFileAction)
 	api.HandleUIMethod(api.GET, "/logging/tail", tailLogFileAction, api.RequireLogin(), api.RequirePermission(logFilesRead))
 }
 

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -11,7 +11,12 @@ package config
 //	GET /logging/files                     list log files (recursive, newest first)
 //	GET /logging/tail?file=&lines=&keyword=  tail a file, optional keyword filter
 //
-// Both are strictly read-only and confined to the configured log directory.
+// Both are strictly read-only. File access goes through util.ReadGuard with
+// the app's own log directory as the only allowed root: paths are
+// symlink-resolved and confined to that directory, system paths
+// (util.IsSystemReadPath) are denied outright, and only regular files are
+// served — the endpoints can never be turned into a general-purpose file
+// reader.
 
 import (
 	"fmt"
@@ -35,20 +40,22 @@ func init() {
 }
 
 const (
-	logTailMaxBytes   = 4 * 1024 * 1024 // scan at most the last 4MB of a file
-	logTailMaxLines   = 2000
+	logTailMaxBytes    = 4 * 1024 * 1024 // scan at most the last 4MB of a file
+	logTailMaxLines    = 2000
 	logReadDirMaxDepth = 6
 )
 
 type logFileInfo struct {
 	Name    string `json:"name"`
-	Path    string `json:"path"`    // relative to the log dir; pass back to /logging/tail
+	Path    string `json:"path"` // relative to the log dir; pass back to /logging/tail
 	Size    int64  `json:"size"`
 	Updated int64  `json:"updated"` // unix seconds
 	Current bool   `json:"current"` // most recently modified file
 }
 
-func logDirAbs() (string, error) {
+// currentLogDir resolves the directory the /logging endpoints serve;
+// overridable in tests.
+var currentLogDir = func() (string, error) {
 	dir := global.Env().GetLogDir()
 	if dir == "" {
 		return "", fmt.Errorf("log dir is not configured")
@@ -60,40 +67,30 @@ func logDirAbs() (string, error) {
 	return abs, nil
 }
 
-// resolveLogFile validates that file (relative to the log dir, or absolute)
-// resolves inside the log dir, and returns its absolute path.
+// resolveLogFile validates that file (relative to the log dir, or absolute
+// inside it) resolves to a regular file strictly inside the log directory,
+// and returns its absolute path.
 func resolveLogFile(file string) (string, error) {
-	logDir, err := logDirAbs()
+	logDir, err := currentLogDir()
 	if err != nil {
 		return "", err
 	}
-	if file == "" {
-		return "", fmt.Errorf("file is required")
-	}
-	target := file
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(logDir, file)
-	}
-	target, err = filepath.Abs(target)
+	guard, err := util.NewReadGuard(logDir)
 	if err != nil {
 		return "", err
 	}
-	// resolve symlinks on both sides to prevent escaping via links
-	if resolvedLogDir, err := filepath.EvalSymlinks(logDir); err == nil {
-		logDir = resolvedLogDir
-	}
-	resolved, err := filepath.EvalSymlinks(target)
-	if err != nil {
-		return "", err
-	}
-	if resolved != logDir && !strings.HasPrefix(resolved, logDir+string(filepath.Separator)) {
-		return "", fmt.Errorf("file [%v] is outside of the log directory", file)
-	}
-	return resolved, nil
+	return guard.ResolveUnder(logDir, file)
 }
 
 func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	logDir, err := logDirAbs()
+	logDir, err := currentLogDir()
+	if err != nil {
+		api.DefaultAPI.WriteError(w, err.Error(), 500)
+		return
+	}
+	// the walk below reports paths as given; make sure logDir itself is
+	// canonical so relative paths handed back to /logging/tail match
+	logDir, err = filepath.Abs(logDir)
 	if err != nil {
 		api.DefaultAPI.WriteError(w, err.Error(), 500)
 		return
@@ -113,6 +110,9 @@ func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.
 			return nil
 		}
 		depth = 0
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
 		if !strings.HasSuffix(fi.Name(), ".log") && !strings.HasSuffix(fi.Name(), ".json") {
 			return nil
 		}
@@ -220,12 +220,12 @@ func tailLogFileAction(w http.ResponseWriter, req *http.Request, ps httprouter.P
 	}
 
 	api.DefaultAPI.WriteJSON(w, util.MapStr{
-		"file":       fileParam,
-		"size":       fi.Size(),
-		"updated":    fi.ModTime().Unix(),
-		"keyword":    keyword,
-		"truncated":  fi.Size() > logTailMaxBytes,
-		"lines":      match,
+		"file":        fileParam,
+		"size":        fi.Size(),
+		"updated":     fi.ModTime().Unix(),
+		"keyword":     keyword,
+		"truncated":   fi.Size() > logTailMaxBytes,
+		"lines":       match,
 		"server_time": time.Now().Unix(),
 	}, 200)
 }

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -1,0 +1,240 @@
+/* ©INFINI, All Rights Reserved.
+ * mail: contact#infini.ltd */
+
+package config
+
+// Instance-local log viewing API, served by every framework app next to the
+// /config/ endpoints (embedded API on agents/gateways). Lets a managing
+// console (e.g. LogPilot) tail instance logs through its reverse channel for
+// pipeline troubleshooting:
+//
+//	GET /logging/files                     list log files (recursive, newest first)
+//	GET /logging/tail?file=&lines=&keyword=  tail a file, optional keyword filter
+//
+// Both are strictly read-only and confined to the configured log directory.
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/util"
+)
+
+func init() {
+	api.HandleAPIMethod(api.GET, "/logging/files", listLogFilesAction)
+	api.HandleAPIMethod(api.GET, "/logging/tail", tailLogFileAction)
+}
+
+const (
+	logTailMaxBytes   = 4 * 1024 * 1024 // scan at most the last 4MB of a file
+	logTailMaxLines   = 2000
+	logReadDirMaxDepth = 6
+)
+
+type logFileInfo struct {
+	Name    string `json:"name"`
+	Path    string `json:"path"`    // relative to the log dir; pass back to /logging/tail
+	Size    int64  `json:"size"`
+	Updated int64  `json:"updated"` // unix seconds
+	Current bool   `json:"current"` // most recently modified file
+}
+
+func logDirAbs() (string, error) {
+	dir := global.Env().GetLogDir()
+	if dir == "" {
+		return "", fmt.Errorf("log dir is not configured")
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// resolveLogFile validates that file (relative to the log dir, or absolute)
+// resolves inside the log dir, and returns its absolute path.
+func resolveLogFile(file string) (string, error) {
+	logDir, err := logDirAbs()
+	if err != nil {
+		return "", err
+	}
+	if file == "" {
+		return "", fmt.Errorf("file is required")
+	}
+	target := file
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(logDir, file)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	// resolve symlinks on both sides to prevent escaping via links
+	if resolvedLogDir, err := filepath.EvalSymlinks(logDir); err == nil {
+		logDir = resolvedLogDir
+	}
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", err
+	}
+	if resolved != logDir && !strings.HasPrefix(resolved, logDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("file [%v] is outside of the log directory", file)
+	}
+	return resolved, nil
+}
+
+func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	logDir, err := logDirAbs()
+	if err != nil {
+		api.DefaultAPI.WriteError(w, err.Error(), 500)
+		return
+	}
+
+	files := []logFileInfo{}
+	depth := 0
+	_ = filepath.Walk(logDir, func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if fi.IsDir() {
+			depth++
+			if depth > logReadDirMaxDepth {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		depth = 0
+		if !strings.HasSuffix(fi.Name(), ".log") && !strings.HasSuffix(fi.Name(), ".json") {
+			return nil
+		}
+		rel, err := filepath.Rel(logDir, p)
+		if err != nil {
+			return nil
+		}
+		files = append(files, logFileInfo{
+			Name:    filepath.ToSlash(rel),
+			Path:    filepath.ToSlash(rel),
+			Size:    fi.Size(),
+			Updated: fi.ModTime().Unix(),
+		})
+		return nil
+	})
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Updated != files[j].Updated {
+			return files[i].Updated > files[j].Updated
+		}
+		return files[i].Name < files[j].Name
+	})
+	if len(files) > 0 {
+		files[0].Current = true
+	}
+
+	api.DefaultAPI.WriteJSON(w, util.MapStr{
+		"log_dir": logDir,
+		"files":   files,
+	}, 200)
+}
+
+func tailLogFileAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	fileParam := req.URL.Query().Get("file")
+	absPath, err := resolveLogFile(fileParam)
+	if err != nil {
+		api.DefaultAPI.WriteError(w, err.Error(), 400)
+		return
+	}
+
+	lines, _ := strconv.Atoi(req.URL.Query().Get("lines"))
+	if lines == 0 {
+		lines = 200
+	}
+	if lines <= 0 {
+		lines = 200
+	}
+	if lines > logTailMaxLines {
+		lines = logTailMaxLines
+	}
+	keyword := strings.ToLower(strings.TrimSpace(req.URL.Query().Get("keyword")))
+
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		api.DefaultAPI.WriteError(w, fmt.Sprintf("stat file failed: %v", err), 400)
+		return
+	}
+
+	f, err := os.Open(absPath)
+	if err != nil {
+		api.DefaultAPI.WriteError(w, fmt.Sprintf("open file failed: %v", err), 400)
+		return
+	}
+	defer f.Close()
+
+	// read a bounded window from the end of the file
+	window := int64(logTailMaxBytes)
+	if fi.Size() < window {
+		window = fi.Size()
+	}
+	buf := make([]byte, window)
+	if _, err = f.ReadAt(buf, fi.Size()-window); err != nil && err.Error() != "EOF" {
+		api.DefaultAPI.WriteError(w, fmt.Sprintf("read file failed: %v", err), 500)
+		return
+	}
+
+	// drop the partial first line when we truncated mid-file
+	if window == logTailMaxBytes && len(buf) > 0 {
+		if idx := indexByte(buf, '\n'); idx >= 0 {
+			buf = buf[idx+1:]
+		}
+	}
+
+	rawLines := strings.Split(strings.ReplaceAll(string(buf), "\r\n", "\n"), "\n")
+	if n := len(rawLines); n > 0 && rawLines[n-1] == "" {
+		rawLines = rawLines[:n-1]
+	}
+
+	match := make([]string, 0, lines)
+	if keyword == "" {
+		if len(rawLines) > lines {
+			match = rawLines[len(rawLines)-lines:]
+		} else {
+			match = rawLines
+		}
+	} else {
+		for i := len(rawLines) - 1; i >= 0 && len(match) < lines; i-- {
+			if strings.Contains(strings.ToLower(rawLines[i]), keyword) {
+				match = append(match, rawLines[i])
+			}
+		}
+		// reversed above, restore chronological order
+		for i, j := 0, len(match)-1; i < j; i, j = i+1, j-1 {
+			match[i], match[j] = match[j], match[i]
+		}
+	}
+
+	api.DefaultAPI.WriteJSON(w, util.MapStr{
+		"file":       fileParam,
+		"size":       fi.Size(),
+		"updated":    fi.ModTime().Unix(),
+		"keyword":    keyword,
+		"truncated":  fi.Size() > logTailMaxBytes,
+		"lines":      match,
+		"server_time": time.Now().Unix(),
+	}, 200)
+}
+
+func indexByte(b []byte, c byte) int {
+	for i, v := range b {
+		if v == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -29,14 +29,23 @@ import (
 	"time"
 
 	"infini.sh/framework/core/api"
+	"infini.sh/framework/core/security"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 )
 
+// logFilesRead gates the log list/tail endpoints; managers mint the
+// instance self API token with this key (see core/security instance-ops
+// catalog) so reverse-channel loopback calls pass the permission filter.
+var logFilesRead = security.GetSimplePermission("generic", "system:log", security.Read)
+
 func init() {
-	api.HandleAPIMethod(api.GET, "/logging/files", listLogFilesAction)
-	api.HandleAPIMethod(api.GET, "/logging/tail", tailLogFileAction)
+	// served on the web port behind login + RBAC: the API domain has no
+	// permission control by default, and embedded mounting additionally
+	// bypasses the web filter chain
+	api.HandleUIMethod(api.GET, "/logging/files", listLogFilesAction, api.RequireLogin(), api.RequirePermission(logFilesRead))
+	api.HandleUIMethod(api.GET, "/logging/tail", tailLogFileAction, api.RequireLogin(), api.RequirePermission(logFilesRead))
 }
 
 const (

--- a/modules/configs/config/logging_files.go
+++ b/modules/configs/config/logging_files.go
@@ -85,18 +85,18 @@ func resolveLogFile(file string) (string, error) {
 func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	logDir, err := currentLogDir()
 	if err != nil {
-		api.DefaultAPI.WriteError(w, err.Error(), 500)
+		api.WriteError(w, err.Error(), 500)
 		return
 	}
 	// the walk below reports paths as given; make sure logDir itself is
 	// canonical so relative paths handed back to /logging/tail match
 	logDir, err = filepath.Abs(logDir)
 	if err != nil {
-		api.DefaultAPI.WriteError(w, err.Error(), 500)
+		api.WriteError(w, err.Error(), 500)
 		return
 	}
 	if util.IsSystemReadPath(logDir) {
-		api.DefaultAPI.WriteError(w, fmt.Sprintf("log dir [%v] is a system path", logDir), 500)
+		api.WriteError(w, fmt.Sprintf("log dir [%v] is a system path", logDir), 500)
 		return
 	}
 
@@ -145,7 +145,7 @@ func listLogFilesAction(w http.ResponseWriter, req *http.Request, ps httprouter.
 		files[0].Current = true
 	}
 
-	api.DefaultAPI.WriteJSON(w, util.MapStr{
+	api.WriteJSON(w, util.MapStr{
 		"log_dir": logDir,
 		"files":   files,
 	}, 200)
@@ -155,7 +155,7 @@ func tailLogFileAction(w http.ResponseWriter, req *http.Request, ps httprouter.P
 	fileParam := req.URL.Query().Get("file")
 	absPath, err := resolveLogFile(fileParam)
 	if err != nil {
-		api.DefaultAPI.WriteError(w, err.Error(), 400)
+		api.WriteError(w, err.Error(), 400)
 		return
 	}
 
@@ -173,13 +173,13 @@ func tailLogFileAction(w http.ResponseWriter, req *http.Request, ps httprouter.P
 
 	fi, err := os.Stat(absPath)
 	if err != nil {
-		api.DefaultAPI.WriteError(w, fmt.Sprintf("stat file failed: %v", err), 400)
+		api.WriteError(w, fmt.Sprintf("stat file failed: %v", err), 400)
 		return
 	}
 
 	f, err := os.Open(absPath)
 	if err != nil {
-		api.DefaultAPI.WriteError(w, fmt.Sprintf("open file failed: %v", err), 400)
+		api.WriteError(w, fmt.Sprintf("open file failed: %v", err), 400)
 		return
 	}
 	defer f.Close()
@@ -191,7 +191,7 @@ func tailLogFileAction(w http.ResponseWriter, req *http.Request, ps httprouter.P
 	}
 	buf := make([]byte, window)
 	if _, err = f.ReadAt(buf, fi.Size()-window); err != nil && err.Error() != "EOF" {
-		api.DefaultAPI.WriteError(w, fmt.Sprintf("read file failed: %v", err), 500)
+		api.WriteError(w, fmt.Sprintf("read file failed: %v", err), 500)
 		return
 	}
 
@@ -226,7 +226,7 @@ func tailLogFileAction(w http.ResponseWriter, req *http.Request, ps httprouter.P
 		}
 	}
 
-	api.DefaultAPI.WriteJSON(w, util.MapStr{
+	api.WriteJSON(w, util.MapStr{
 		"file":        fileParam,
 		"size":        fi.Size(),
 		"updated":     fi.ModTime().Unix(),

--- a/modules/configs/config/logging_files_test.go
+++ b/modules/configs/config/logging_files_test.go
@@ -1,0 +1,102 @@
+/* ©INFINI, All Rights Reserved.
+ * mail: contact#infini.ltd */
+
+package config
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	httprouter "infini.sh/framework/core/api/router"
+)
+
+func stubLogDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := currentLogDir
+	currentLogDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { currentLogDir = orig })
+}
+
+func callTail(t *testing.T, file string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/logging/tail?file="+url.QueryEscape(file), nil)
+	w := httptest.NewRecorder()
+	tailLogFileAction(w, req, httprouter.Params{})
+	return w
+}
+
+func TestTailLogFileAction(t *testing.T) {
+	dir := t.TempDir()
+	stubLogDir(t, dir)
+
+	logFile := filepath.Join(dir, "server.log")
+	content := "first\nsecond\nthird\n"
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := callTail(t, "server.log")
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "third") {
+		t.Errorf("expected tailed content in response: %s", w.Body.String())
+	}
+
+	for _, bad := range []string{
+		"../../../etc/passwd",
+		"/etc/passwd",
+		"missing.log",
+		"",
+	} {
+		if w := callTail(t, bad); w.Code != 400 {
+			t.Errorf("expected 400 for file [%q], got %d: %s", bad, w.Code, w.Body.String())
+		}
+	}
+
+	link := filepath.Join(dir, "escape.log")
+	if err := os.Symlink("/etc/passwd", link); err != nil {
+		t.Fatal(err)
+	}
+	if w := callTail(t, "escape.log"); w.Code != 400 {
+		t.Errorf("expected 400 for symlink escape, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListLogFilesAction(t *testing.T) {
+	dir := t.TempDir()
+	stubLogDir(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "server.log"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "nested", "slowlog.json"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/logging/files", nil)
+	w := httptest.NewRecorder()
+	listLogFilesAction(w, req, httprouter.Params{})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{"server.log", "nested/slowlog.json"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected [%s] in listing: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "notes.txt") {
+		t.Errorf("expected non-log file to be excluded: %s", body)
+	}
+}

--- a/modules/configs/config/logging_files_test.go
+++ b/modules/configs/config/logging_files_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -64,6 +65,49 @@ func TestTailLogFileAction(t *testing.T) {
 	}
 	if w := callTail(t, "escape.log"); w.Code != 400 {
 		t.Errorf("expected 400 for symlink escape, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListLogFilesActionRejectsSystemLogDir(t *testing.T) {
+	stubLogDir(t, "/etc")
+
+	req := httptest.NewRequest("GET", "/logging/files", nil)
+	w := httptest.NewRecorder()
+	listLogFilesAction(w, req, httprouter.Params{})
+	if w.Code != 500 {
+		t.Errorf("expected 500 for system path as log dir, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListLogFilesActionDepthResetsBetweenSiblings(t *testing.T) {
+	dir := t.TempDir()
+	stubLogDir(t, dir)
+
+	// a deep chain first so a buggy depth counter stays high, then a
+	// shallow sibling directory that must still be listed
+	deep := dir
+	for i := 0; i < logReadDirMaxDepth+2; i++ {
+		deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+	}
+	if err := os.MkdirAll(deep, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sibling := filepath.Join(dir, "shallow")
+	if err := os.Mkdir(sibling, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sibling, "server.log"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/logging/files", nil)
+	w := httptest.NewRecorder()
+	listLogFilesAction(w, req, httprouter.Params{})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "shallow/server.log") {
+		t.Errorf("expected shallow sibling file to be listed: %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Read-only instance log viewing API for framework apps:

- `GET /logging/files` — list log files under the configured `path.logs` (name, size, modified time; relative paths)
- `GET /logging/tail?file=<rel>&lines=<n>&keyword=<s>` — bounded tail (default 200 lines, max 2000 / 4MB) with optional keyword filter

**Dual registration**: the API-domain registration stays for existing API-port consumers; the web-domain copy is the secured one — `api.HandleUIMethod` + `api.RequireLogin()` + `api.RequirePermission(generic#system:log/read)`. The reverse-channel loopback targets the web port, so managers (logpilot's logs panel) get the RBAC-gated copy and pass via the instance self API token carrying `security.InstanceOpsPermissionKeys()` (#422 + its companion agent PR).

This also fixes reachability on agents: `HandleAPIMethod` routes never exist on a stock agent (api disabled, no embedding) while the loopback always targets the web port — previously these endpoints 404'd on agents; the UI-domain copy is always served on the web port.

## Security model

- **Whitelist**: files must resolve strictly under the configured log directory (`util.ReadGuard`, symlink-resolved).
- **System-path hard deny**: the log dir itself is rejected if it canonicalizes onto an OS-critical subtree (`util.IsSystemReadPath` — `/etc`, `/usr/bin`, `/root`, `/System`, Windows `\Windows`, …); deny wins over the whitelist.
- **Regular files only** — devices/FIFOs/symlinks-to-elsewhere are skipped or rejected.
- `..` traversal and symlink escapes are rejected with 400.
