### PR TITLE
fix(model): drop unbalanced brace in instance.groups elastic_mapping

### DIFF
--- a/core/model/instance.go
+++ b/core/model/instance.go
@@ -63,7 +63,7 @@ type Instance struct {
 	// "gateway-edge"): managed from the management UI, used to target
 	// config delivery (ManagedConfig.Groups). Instances do not report it —
 	// registration/heartbeat upserts preserve the stored value.
-	Groups []string `json:"groups,omitempty" elastic_mapping:"groups:{type:keyword}}"`
+	Groups []string `json:"groups,omitempty" elastic_mapping:"groups:{type:keyword}"`
 
 	//user can pass
 	Description string `json:"description,omitempty" config:"description" elastic_mapping:"description:{type:keyword}"`


### PR DESCRIPTION
## Summary

`instance.groups` carried an unbalanced brace in its `elastic_mapping` which panicked schema init on template recreation.

Split from #416.

## Test plan

- `go build ./core/model/...`

🤖 Generated with ZCode